### PR TITLE
fixes/map-generator

### DIFF
--- a/frontend/src/common/map/map-generator.ts
+++ b/frontend/src/common/map/map-generator.ts
@@ -81,7 +81,6 @@ export class MapGenerator {
       rows,
       columns,
       startPosition: { x: 0, y: 0 },
-      finishPosition: { x: 0, y: 0 },
       assetGroups: new Map(),
     };
   }
@@ -211,36 +210,6 @@ export class MapGenerator {
     return arrayOfTiles[0];
   }
 
-  replaceColisionablesWithFrequency(map: Tiles[][]): void {
-    const frecuency = TILES_TO_USE.filter(
-      (f) =>
-        f.Type === MapTileType.INTERACTABLE_OBJECT ||
-        f.Type === MapTileType.EMPTY_SPACE,
-    ).map((m) => m.Frecuency!);
-    const assets = TILES_TO_USE.filter(
-      (f) =>
-        f.Type === MapTileType.INTERACTABLE_OBJECT ||
-        f.Type === MapTileType.EMPTY_SPACE,
-    ).map((m) => m.Asset);
-
-    for (let y = 0; y < map.length; y += 1) {
-      for (let x = 0; x < map[y]!.length; x += 1) {
-        if (this.#matrix[y]![x] === UNUSED_CELL) {
-          if (
-            this.#map.startPosition.x === 0 &&
-            this.#map.startPosition.y === 0
-          ) {
-            this.#map.startPosition.x = x;
-            this.#map.startPosition.y = y;
-          }
-          this.#map.tiles[y]![x] = this.getRandomBasedOnFrequency(
-            frecuency,
-            assets,
-          ); // Reemplaza solo celdas vacías
-        }
-      }
-    }
-  }
 
   fillMap(map: Tiles[][], partition: Partition): void {
     if (partition.room) {
@@ -290,7 +259,7 @@ export class MapGenerator {
       const index = rooms.indexOf(room);
       rooms.splice(index, 1);
 
-      this.#map.tiles[room.x + room.width / 2]![room.y + room.height / 2] =
+      this.#map.tiles[room.x + Math.trunc(room.width / 2)]![room.y + Math.trunc(room.height / 2)] =
         Tiles.FREE_SPACE;
     }
   }
@@ -322,6 +291,10 @@ export class MapGenerator {
               frecuencyInteractuableAndEmptySpace,
               assetsInteractuableAndEmptySpace,
             );
+            if(this.#map.startPosition.x == 0 && this.#map.startPosition.y==0){
+              this.#map.startPosition.x = columnIndex +1;
+              this.#map.startPosition.y = rowIndex +1;
+            }
         }
         if (element === UNUSED_CELL) {
           this.#map.tiles[columnIndex]![rowIndex] =

--- a/frontend/src/common/map/map-generator.ts
+++ b/frontend/src/common/map/map-generator.ts
@@ -210,7 +210,6 @@ export class MapGenerator {
     return arrayOfTiles[0];
   }
 
-
   fillMap(map: Tiles[][], partition: Partition): void {
     if (partition.room) {
       const { x, y, width, height } = partition.room;
@@ -259,8 +258,9 @@ export class MapGenerator {
       const index = rooms.indexOf(room);
       rooms.splice(index, 1);
 
-      this.#map.tiles[room.x + Math.trunc(room.width / 2)]![room.y + Math.trunc(room.height / 2)] =
-        Tiles.FREE_SPACE;
+      this.#map.tiles[room.x + Math.trunc(room.width / 2)]![
+        room.y + Math.trunc(room.height / 2)
+      ] = Tiles.FREE_SPACE;
     }
   }
 
@@ -291,10 +291,13 @@ export class MapGenerator {
               frecuencyInteractuableAndEmptySpace,
               assetsInteractuableAndEmptySpace,
             );
-            if(this.#map.startPosition.x == 0 && this.#map.startPosition.y==0){
-              this.#map.startPosition.x = columnIndex +1;
-              this.#map.startPosition.y = rowIndex +1;
-            }
+          if (
+            this.#map.startPosition.x === 0 &&
+            this.#map.startPosition.y === 0
+          ) {
+            this.#map.startPosition.x = columnIndex + 1;
+            this.#map.startPosition.y = rowIndex + 1;
+          }
         }
         if (element === UNUSED_CELL) {
           this.#map.tiles[columnIndex]![rowIndex] =

--- a/frontend/src/common/map/map-renderer.ts
+++ b/frontend/src/common/map/map-renderer.ts
@@ -9,15 +9,15 @@ import { AnimationsKeys } from "assets/animation-keys";
 export class MapRenderer {
   static renderer(scene: Scene, map: MapStructure) {
     const { rows: numberOfRows, columns: numberOfColumns } = map;
-    const startPosition: Coordinate = { x: 100, y: 100 };
+    const startPosition = {x: 0, y:0 };
 
     let numberOfNPCs = 2;
     const assetNPC = [0, 20];
 
     for (let row = 0; row < numberOfRows; row += 1) {
       for (let column = 0; column < numberOfColumns; column += 1) {
-        const x = startPosition.x + column * TILE_SIZE;
-        const y = startPosition.y + row * TILE_SIZE;
+        const x = startPosition.x + TILE_SIZE + column * TILE_SIZE;
+        const y = startPosition.y + TILE_SIZE + row * TILE_SIZE;
 
         const assetRef = (map.tiles[row]?.[column] as Tiles) ?? 0;
         const assetName = Tiles[assetRef]!;

--- a/frontend/src/common/map/map-renderer.ts
+++ b/frontend/src/common/map/map-renderer.ts
@@ -3,13 +3,12 @@ import { AssetKeys } from "assets/asset-keys";
 import type { MapStructure } from "types/map";
 import { TILE_SIZE } from "config/config";
 import { Tiles } from "config/map-config";
-import type { Coordinate } from "types/coordinate";
 import { AnimationsKeys } from "assets/animation-keys";
 
 export class MapRenderer {
   static renderer(scene: Scene, map: MapStructure) {
     const { rows: numberOfRows, columns: numberOfColumns } = map;
-    const startPosition = {x: 0, y:0 };
+    const startPosition = { x: 0, y: 0 };
 
     let numberOfNPCs = 2;
     const assetNPC = [0, 20];

--- a/frontend/src/config/map-config.ts
+++ b/frontend/src/config/map-config.ts
@@ -60,7 +60,7 @@ export const TILES_TO_USE: TilesToUseConfig[] = [
   },
   {
     Type: MapTileType.NO_INTERACTABLE_OBJECT, // EL 100% DE LOS OBJETOS INTERACTUABL SON ARBOLES
-    Asset: Tiles.TREE,
+    Asset: Tiles.GRASS,
     Frecuency: 50,
   },
   {
@@ -70,10 +70,10 @@ export const TILES_TO_USE: TilesToUseConfig[] = [
   },
 ];
 
-export const MAP_WIDTH = 10;
-export const MAP_HEIGHT = 10;
-export const MIN_PARTITION_SIZE = 4;
-export const MIN_ROOM_SIZE = 4;
+export const MAP_WIDTH = 120;
+export const MAP_HEIGHT = 120;
+export const MIN_PARTITION_SIZE = 5; //MIN_PARTITION_SIZE < MIN(MAP_WIDTH, MAP_HEIGHT) / 2
+export const MIN_ROOM_SIZE = 5; //MIN_ROOM_SIZE < MIN(MAP_WIDTH, MAP_HEIGHT) / 2
 
 export const MAP_TILES_ASSETS: { [key: number]: string } = {
   0: AssetKeys.TILES.GRASS,

--- a/frontend/src/config/map-config.ts
+++ b/frontend/src/config/map-config.ts
@@ -72,8 +72,8 @@ export const TILES_TO_USE: TilesToUseConfig[] = [
 
 export const MAP_WIDTH = 120;
 export const MAP_HEIGHT = 120;
-export const MIN_PARTITION_SIZE = 5; //MIN_PARTITION_SIZE < MIN(MAP_WIDTH, MAP_HEIGHT) / 2
-export const MIN_ROOM_SIZE = 5; //MIN_ROOM_SIZE < MIN(MAP_WIDTH, MAP_HEIGHT) / 2
+export const MIN_PARTITION_SIZE = 5; // MIN_PARTITION_SIZE < MIN(MAP_WIDTH, MAP_HEIGHT) / 2
+export const MIN_ROOM_SIZE = 5; // MIN_ROOM_SIZE < MIN(MAP_WIDTH, MAP_HEIGHT) / 2
 
 export const MAP_TILES_ASSETS: { [key: number]: string } = {
   0: AssetKeys.TILES.GRASS,

--- a/frontend/src/scenes/base-scene.ts
+++ b/frontend/src/scenes/base-scene.ts
@@ -108,8 +108,8 @@ export class BaseScene extends Scene {
     this._player = new Player({
       scene: this,
       position: {
-        x: 100 + this._map.startPosition.x * TILE_SIZE,
-        y: 100 + this._map.startPosition.y * TILE_SIZE,
+        x: 0 + TILE_SIZE + this._map.startPosition.x * TILE_SIZE,
+        y: 0 + TILE_SIZE + this._map.startPosition.y * TILE_SIZE,
       },
       velocity: 700,
     });

--- a/frontend/src/scenes/level1.ts
+++ b/frontend/src/scenes/level1.ts
@@ -57,17 +57,14 @@ export class Level1 extends BaseScene {
       this.#defineBehaviorForNPCs(npcSprite);
     });
 
-    this.physics.add.collider(this._player, orangeGroup, (_player, item) => {
-      const itemObject = item as Phaser.GameObjects.Sprite;
-      this.#defineBehaviorForItems(itemObject);
-    });
+    
   }
 
   #defineBehaviorForNPCs(npc: Phaser.GameObjects.Sprite) {
     this.#total_oranges = this._map.assetGroups
       .get(AssetKeys.ITEMS.FRUITS.ORANGE.NAME)!
       .getLength();
-
+      
     if (this._controls.wasSpaceKeyPressed()) {
       if (npc.name === "npc-1") {
         const orangeGroup = this._map.assetGroups.get(
@@ -77,6 +74,10 @@ export class Level1 extends BaseScene {
         if (this.#npc_1_show_first_message) {
           this._dialog?.show(npc.name);
           this._showElements(orangeGroup!);
+          this.physics.add.collider(this._player, orangeGroup, (_player, item) => {
+            const itemObject = item as Phaser.GameObjects.Sprite;
+            this.#defineBehaviorForItems(itemObject);
+          });
           this._dialog?.setMessageComplete(npc.name);
           this.#npc_1_show_first_message = false;
         } else if (this.#total_oranges > 0) {
@@ -103,6 +104,8 @@ export class Level1 extends BaseScene {
   }
 
   #defineBehaviorForItems(item: Phaser.GameObjects.Sprite) {
-    item.destroy();
+    if(item.visible){
+      item.destroy();
+    }
   }
 }

--- a/frontend/src/scenes/level1.ts
+++ b/frontend/src/scenes/level1.ts
@@ -56,15 +56,13 @@ export class Level1 extends BaseScene {
       const npcSprite = npc as Phaser.GameObjects.Sprite;
       this.#defineBehaviorForNPCs(npcSprite);
     });
-
-    
   }
 
   #defineBehaviorForNPCs(npc: Phaser.GameObjects.Sprite) {
     this.#total_oranges = this._map.assetGroups
       .get(AssetKeys.ITEMS.FRUITS.ORANGE.NAME)!
       .getLength();
-      
+
     if (this._controls.wasSpaceKeyPressed()) {
       if (npc.name === "npc-1") {
         const orangeGroup = this._map.assetGroups.get(
@@ -74,10 +72,14 @@ export class Level1 extends BaseScene {
         if (this.#npc_1_show_first_message) {
           this._dialog?.show(npc.name);
           this._showElements(orangeGroup!);
-          this.physics.add.collider(this._player, orangeGroup, (_player, item) => {
-            const itemObject = item as Phaser.GameObjects.Sprite;
-            this.#defineBehaviorForItems(itemObject);
-          });
+          this.physics.add.collider(
+            this._player,
+            orangeGroup,
+            (_player, item) => {
+              const itemObject = item as Phaser.GameObjects.Sprite;
+              this.#defineBehaviorForItems(itemObject);
+            },
+          );
           this._dialog?.setMessageComplete(npc.name);
           this.#npc_1_show_first_message = false;
         } else if (this.#total_oranges > 0) {
@@ -104,7 +106,7 @@ export class Level1 extends BaseScene {
   }
 
   #defineBehaviorForItems(item: Phaser.GameObjects.Sprite) {
-    if(item.visible){
+    if (item.visible) {
       item.destroy();
     }
   }

--- a/frontend/src/types/map.d.ts
+++ b/frontend/src/types/map.d.ts
@@ -29,7 +29,6 @@ export type MapStructure = {
   rows: number;
   columns: number;
   startPosition: Coordinate;
-  finishPosition: Coordinate;
   assetGroups: Map<string, Phaser.GameObjects.Group>;
   initialParameters?: MapConfig;
 };


### PR DESCRIPTION
Arregle el bug de las naranjas, el problema es que colicionaba con naranjas que no se veian, ahora el colide se ejecuta luego del show en el level1
Arregle el problema de que no aparecian los NPC, el problema era que no estaba truncando cuando accedia a la matriz
Cambie las frecuencia de los arboles por arboles y pásto en el config
Borre el finishPosition o algo asi que no se estaba usando