### PR TITLE
feat: item now drops based on player's direction

### DIFF
--- a/frontend/src/common/player.ts
+++ b/frontend/src/common/player.ts
@@ -10,11 +10,19 @@ type PlayerConfig = {
 };
 
 export class Player extends Phaser.Physics.Arcade.Sprite {
-  #direction: Direction;
+  private _direction: Direction = DIRECTION.NONE;
 
-  #velocity: number;
+  private velocity: number;
 
-  isMoving: boolean;
+  isMoving: boolean = false;
+
+  get direction(): Direction {
+    return this._direction;
+  }
+
+  set direction(direction: Direction) {
+    this._direction = direction;
+  }
 
   constructor(config: PlayerConfig) {
     super(
@@ -25,13 +33,11 @@ export class Player extends Phaser.Physics.Arcade.Sprite {
       config.frame,
     );
 
-    this.isMoving = false;
     config.scene.add.existing(this);
     config.scene.physics.add.existing(this);
 
     (this.body as Phaser.Physics.Arcade.Body).setMaxVelocity(config.velocity);
-    this.#direction = DIRECTION.NONE;
-    this.#velocity = config.velocity;
+    this.velocity = config.velocity;
     this.setScale(0.8);
   }
 
@@ -41,19 +47,26 @@ export class Player extends Phaser.Physics.Arcade.Sprite {
       this.anims.stop();
       this.setVelocity(0);
     } else {
-      if (direction === DIRECTION.UP) {
-        this.setVelocity(0, -this.#velocity);
-      } else if (direction === DIRECTION.DOWN) {
-        this.setVelocity(0, this.#velocity);
-      } else if (direction === DIRECTION.LEFT) {
-        this.setVelocity(-this.#velocity, 0);
-      } else if (direction === DIRECTION.RIGHT) {
-        this.setVelocity(this.#velocity, 0);
+      switch (direction) {
+        case DIRECTION.UP:
+          this.setVelocity(0, -this.velocity);
+          break;
+        case DIRECTION.DOWN:
+          this.setVelocity(0, this.velocity);
+          break;
+        case DIRECTION.LEFT:
+          this.setVelocity(-this.velocity, 0);
+          break;
+        case DIRECTION.RIGHT:
+          this.setVelocity(this.velocity, 0);
+          break;
+        default:
+          this.setVelocity(0, 0);
       }
 
       this.isMoving = true;
-      this.#direction = direction;
-      this.anims.play(`PLAYER_${this.#direction}_ANIMATION`, true);
+      this._direction = direction;
+      this.anims.play(`PLAYER_${this._direction}_ANIMATION`, true);
     }
   }
 }


### PR DESCRIPTION
This pull request includes several changes to the `Player` class in `frontend/src/common/player.ts` and the `BaseScene` class in `frontend/src/scenes/base-scene.ts`. The changes aim to improve code readability and functionality by replacing private fields with private properties, adding getter and setter methods, and using switch statements for better clarity.

Improvements to the `Player` class:

* Replaced private fields `#direction` and `#velocity` with private properties `_direction` and `velocity`. Added getter and setter methods for `_direction` to manage the player's direction.
* Removed redundant initialization of `isMoving` in the constructor and moved it to the property declaration.
* Refactored the movement logic to use a switch statement instead of multiple if-else statements for setting velocity based on direction.

Enhancements to the `BaseScene` class:

* Added import for `DIRECTION` to support direction-based logic.
* Changed `this.physics.add.overlap` to `this.physics.add.collider` to improve collision handling.
* Refactored the `tryDropHeldItem` method to use a switch statement for determining drop coordinates based on the player's direction, improving readability and maintainability.