### PR TITLE
feat: add logic to determine if a level is completed

### DIFF
--- a/frontend/src/common-ui/base-dialog.ts
+++ b/frontend/src/common-ui/base-dialog.ts
@@ -58,6 +58,10 @@ export abstract class BaseDialog extends UIComponent {
       config.width || this.scene.cameras.main.width - this.padding * 2;
   }
 
+  areAllDialogsCompleted(): boolean {
+    return this.data.every((dialog) => dialog.completed);
+  }
+
   protected initializeUI(): void {
     this.statementUI = this.createUIText();
     this.createContainer([this.createPanel(), this.statementUI]);

--- a/frontend/src/scenes/base-scene.ts
+++ b/frontend/src/scenes/base-scene.ts
@@ -343,6 +343,11 @@ export abstract class BaseScene extends Scene {
     if (this.remainingQuestItems === 0) {
       this.dialog?.setMessageComplete(npc.name);
       this.dialog?.show(npc.name);
+
+      if (this.dialog?.areAllDialogsCompleted()) {
+        this.cameras.main.fadeOut(1000, 0, 0, 0);
+        this.scene.start(SceneKeys.GAME_OVER);
+      }
     }
   }
 


### PR DESCRIPTION
This pull request introduces a new method to check if all dialogs are completed and integrates this check into the game scene logic to trigger the game over sequence. The changes include additions to both the `BaseDialog` and `BaseScene` classes.

Improvements to dialog handling:

* [`frontend/src/common-ui/base-dialog.ts`](diffhunk://#diff-654a90a17c569b8d91787f38324c52ee69bd1a43d1a0e0d30ccc234201e806f7R61-R64): Added a new method `areAllDialogsCompleted` to the `BaseDialog` class to check if all dialogs are completed.

Game scene logic enhancement:

* [`frontend/src/scenes/base-scene.ts`](diffhunk://#diff-ebb4d342a85838a95354d7a8097af326b4d20a99f7868a9904c3f01366d34d35R346-R350): Updated the `BaseScene` class to use the new `areAllDialogsCompleted` method. If all dialogs are completed, the main camera fades out and the scene transitions to the game over scene.