### PR TITLE
fix: correct level completion logic, awards, and dialogues  

### DIFF
--- a/frontend/public/assets/data/level_1.json
+++ b/frontend/public/assets/data/level_1.json
@@ -8,22 +8,23 @@
         "Can you pick the oranges?",
         "They're for making marmalade."
       ],
-      "questStartIAGenerated": ["EXAMPLE"],
+      "questStartIAGenerated": [""],
       "questInProgress": [
         "I need all the oranges you can find so I can cook them!"
       ],
-      "questInProgressIAGenerated": ["EXAMPLE"],
+      "questInProgressIAGenerated": [""],
       "questFinished": [
         "Thank you! Now I can make the marmalade my grandma used to make!"
       ],
-      "questFinishedIAGenerated": ["EXAMPLE"],
+      "questFinishedIAGenerated": [""],
       "hints": [
         "I'll give you a hint! Oranges are round and orange!",
         "I don't have nothing more to say!"
       ],
-      "hintsIAGenerated": ["EXAMPLE"],
+      "hintsIAGenerated": [""],
       "assetKey": "ORANGE",
-      "quantityToCollect": 5
+      "quantityToCollect": 1,
+      "disable": false
     },
     {
       "id": "d-2",
@@ -34,7 +35,8 @@
       ],
       "questInProgress": [],
       "questFinished": ["Thank you so much!"],
-      "hints": []
+      "hints": [],
+      "disable": true
     },
     {
       "id": "dwo-1",
@@ -43,7 +45,8 @@
       "questInProgress": [],
       "questFinished": [],
       "options": ["opcion 1", "opcion 2", "opcion 3", "opcion 4"],
-      "correctOption": "opcion 1"
+      "correctOption": "opcion 1",
+      "disable": true
     }
   ]
 }

--- a/frontend/src/common-ui/awards.ts
+++ b/frontend/src/common-ui/awards.ts
@@ -79,7 +79,7 @@ export class Awards {
       this.removeAward(countDifference * -1);
     }
 
-    this.container.visible = countDifference > 0;
+    this.container.visible = this.sprites.length > 0;
   }
 
   private initializeUI(): void {

--- a/frontend/src/scenes/base-scene.ts
+++ b/frontend/src/scenes/base-scene.ts
@@ -351,11 +351,9 @@ export abstract class BaseScene extends Scene {
   }
 
   private levelCompleted(): void {
-    this.cameras.main.fadeOut(20000, 0, 0, 0,
-      () => {
-        this.scene.start(SceneKeys.LEVELS_MENU);
-      }
-    );
+    this.cameras.main.fadeOut(20000, 0, 0, 0, () => {
+      this.scene.start(SceneKeys.LEVELS_MENU);
+    });
   }
 
   private applyWrongItemPenalty(): void {

--- a/frontend/src/scenes/base-scene.ts
+++ b/frontend/src/scenes/base-scene.ts
@@ -345,10 +345,17 @@ export abstract class BaseScene extends Scene {
       this.dialog?.show(npc.name);
 
       if (this.dialog?.areAllDialogsCompleted()) {
-        this.cameras.main.fadeOut(1000, 0, 0, 0);
-        this.scene.start(SceneKeys.GAME_OVER);
+        this.levelCompleted();
       }
     }
+  }
+
+  private levelCompleted(): void {
+    this.cameras.main.fadeOut(20000, 0, 0, 0,
+      () => {
+        this.scene.start(SceneKeys.LEVELS_MENU);
+      }
+    );
   }
 
   private applyWrongItemPenalty(): void {

--- a/frontend/src/scenes/level1.ts
+++ b/frontend/src/scenes/level1.ts
@@ -45,7 +45,7 @@ export const level1Config: TileConfig[] = [
       type: TileType.INTERACTIVE_OBJECT,
       asset: AssetKeys.ITEMS.FRUITS.STRAWBERRY.ASSET_KEY,
     },
-    frequency: 10,
+    frequency: 5,
   },
 ];
 

--- a/frontend/src/types/level-data.d.ts
+++ b/frontend/src/types/level-data.d.ts
@@ -10,6 +10,7 @@ export type DialogData = {
   assetKey: string | undefined;
   quantityToCollect: number | undefined;
   completed: boolean | undefined;
+  disable: boolean | undefined;
 };
 
 export type RawDialogData = {
@@ -27,6 +28,7 @@ export type RawDialogData = {
   correctOption: string | undefined;
   assetKey: string | undefined;
   quantityToCollect: number | undefined;
+  disable: boolean | undefined;
 };
 
 export type LevelData = {

--- a/frontend/src/utils/data-util.ts
+++ b/frontend/src/utils/data-util.ts
@@ -6,34 +6,32 @@ export const loadLevelData = (
 ): LevelData => {
   const rawData = scene.cache.json.get(level);
 
-  const convertedDialogs = rawData.dialogs.map((dialog: RawDialogData) => {
-    const convertedDialog: DialogData = {
+  const convertedDialogs = rawData.dialogs.map((dialog: RawDialogData): DialogData => ({
       id: dialog.id,
       description: dialog.description,
       questStart: [
-        ...(dialog.questStart || []),
-        ...(dialog.questStartIAGenerated || []),
+        ...((dialog.questStart ?? []).filter(Boolean)),
+        ...((dialog.questStartIAGenerated ?? []).filter(Boolean)),
       ],
       questInProgress: [
-        ...(dialog.questInProgress || []),
-        ...(dialog.questInProgressIAGenerated || []),
+        ...((dialog.questInProgress ?? []).filter(Boolean)),
+        ...((dialog.questInProgressIAGenerated ?? []).filter(Boolean)),
       ],
       questFinished: [
-        ...(dialog.questFinished || []),
-        ...(dialog.questFinishedIAGenerated || []),
+        ...((dialog.questFinished ?? []).filter(Boolean)),
+        ...((dialog.questFinishedIAGenerated ?? []).filter(Boolean)),
       ],
-      hints: [...(dialog.hints || []), ...(dialog.hintsIAGenerated || [])],
+      hints: [...((dialog.hints ?? []).filter(Boolean)), ...((dialog.hintsIAGenerated ?? []).filter(Boolean))],
       options: dialog.options,
       correctOption: dialog.correctOption,
       assetKey: dialog.assetKey,
       quantityToCollect: dialog.quantityToCollect,
       completed: false,
-    };
-    return convertedDialog;
-  });
+      disable: dialog.disable ?? true,
+    }));
 
   return {
     title: rawData.title,
-    dialogs: convertedDialogs,
+    dialogs: convertedDialogs.filter((dialog: DialogData) => !dialog.disable),
   };
 };

--- a/frontend/src/utils/data-util.ts
+++ b/frontend/src/utils/data-util.ts
@@ -31,7 +31,7 @@ export const loadLevelData = (
       assetKey: dialog.assetKey,
       quantityToCollect: dialog.quantityToCollect,
       completed: false,
-      disable: dialog.disable ?? true,
+      disable: dialog.disable ?? false,
     }),
   );
 

--- a/frontend/src/utils/data-util.ts
+++ b/frontend/src/utils/data-util.ts
@@ -6,29 +6,34 @@ export const loadLevelData = (
 ): LevelData => {
   const rawData = scene.cache.json.get(level);
 
-  const convertedDialogs = rawData.dialogs.map((dialog: RawDialogData): DialogData => ({
+  const convertedDialogs = rawData.dialogs.map(
+    (dialog: RawDialogData): DialogData => ({
       id: dialog.id,
       description: dialog.description,
       questStart: [
-        ...((dialog.questStart ?? []).filter(Boolean)),
-        ...((dialog.questStartIAGenerated ?? []).filter(Boolean)),
+        ...(dialog.questStart ?? []).filter(Boolean),
+        ...(dialog.questStartIAGenerated ?? []).filter(Boolean),
       ],
       questInProgress: [
-        ...((dialog.questInProgress ?? []).filter(Boolean)),
-        ...((dialog.questInProgressIAGenerated ?? []).filter(Boolean)),
+        ...(dialog.questInProgress ?? []).filter(Boolean),
+        ...(dialog.questInProgressIAGenerated ?? []).filter(Boolean),
       ],
       questFinished: [
-        ...((dialog.questFinished ?? []).filter(Boolean)),
-        ...((dialog.questFinishedIAGenerated ?? []).filter(Boolean)),
+        ...(dialog.questFinished ?? []).filter(Boolean),
+        ...(dialog.questFinishedIAGenerated ?? []).filter(Boolean),
       ],
-      hints: [...((dialog.hints ?? []).filter(Boolean)), ...((dialog.hintsIAGenerated ?? []).filter(Boolean))],
+      hints: [
+        ...(dialog.hints ?? []).filter(Boolean),
+        ...(dialog.hintsIAGenerated ?? []).filter(Boolean),
+      ],
       options: dialog.options,
       correctOption: dialog.correctOption,
       assetKey: dialog.assetKey,
       quantityToCollect: dialog.quantityToCollect,
       completed: false,
       disable: dialog.disable ?? true,
-    }));
+    }),
+  );
 
   return {
     title: rawData.title,


### PR DESCRIPTION
This pull request includes multiple changes aimed at improving the game data structure, enhancing the user interface, and optimizing the game logic. The most important changes are grouped by theme below:

### Game Data Structure Improvements:
* [`frontend/public/assets/data/level_1.json`](diffhunk://#diff-0c454196904c49d69582deb3bfd4c3a78944610e85507364652c43e9d8541bacL11-R27): Updated quest-related fields to remove placeholder "EXAMPLE" text and added a `disable` flag to certain quests. [[1]](diffhunk://#diff-0c454196904c49d69582deb3bfd4c3a78944610e85507364652c43e9d8541bacL11-R27) [[2]](diffhunk://#diff-0c454196904c49d69582deb3bfd4c3a78944610e85507364652c43e9d8541bacL37-R39) [[3]](diffhunk://#diff-0c454196904c49d69582deb3bfd4c3a78944610e85507364652c43e9d8541bacL46-R49)

### User Interface Enhancements:
* [`frontend/src/common-ui/awards.ts`](diffhunk://#diff-e024cf6b80074b60791b6d3ffe481c7b934b4b5648e65a1fee652f2584708becL82-R82): Modified the visibility logic of the awards container to depend on the number of sprites instead of the count difference.

### Game Logic Optimization:
* [`frontend/src/scenes/base-scene.ts`](diffhunk://#diff-ebb4d342a85838a95354d7a8097af326b4d20a99f7868a9904c3f01366d34d35L348-R358): Refactored the scene transition logic by extracting the level completion functionality into a new `levelCompleted` method and adjusting the fade-out duration.
* [`frontend/src/scenes/level1.ts`](diffhunk://#diff-ef8fc8a455c1f522657183928990122aa78d1420b2b071feed09dabeae357eb2L48-R48): Reduced the frequency of a specific interactive object to improve gameplay balance.
* [`frontend/src/utils/data-util.ts`](diffhunk://#diff-abfef6c0ca6bdc6eb89db6b06751c8f3670ad466fcc1836ebcc173c64b15465fL9-R35): Enhanced the data loading utility to filter out empty quest fields and disable certain dialogs by default.