### PR TITLE
feat: add dialog support for wrong item interactions

### DIFF
--- a/backend/src/api/v1/controllers/gemini_controller.py
+++ b/backend/src/api/v1/controllers/gemini_controller.py
@@ -15,7 +15,13 @@ async def get_paraphrase(dialogData: DialogContentInput):
         "sentences as an array separated by ';':"
     )
 
-    DIALOG_TYPES = ["questStart", "questInProgress", "questFinished", "hints"]
+    DIALOG_TYPES = [
+        "questStart",
+        "questInProgress",
+        "questFinished",
+        "hints",
+        "questWrongItem",
+    ]
     generated_results = {}
 
     with ThreadPoolExecutor() as executor:

--- a/frontend/public/assets/data/level_1.json
+++ b/frontend/public/assets/data/level_1.json
@@ -16,6 +16,11 @@
       "questInProgressIAGenerated": [""],
       "questFinished": ["Thank you! Now I can make the marmalade!"],
       "questFinishedIAGenerated": [""],
+      "questWrongItem": [
+        "That's not an orange! I need oranges for the marmalade.",
+        "Sorry, but I specifically asked for oranges. That won't work!"
+      ],
+      "questWrongItemIAGenerated": [""],
       "hints": [
         "I'll give you a hint! Oranges are round and orange!",
         "I don't have nothing more to say! Good luck!"

--- a/frontend/src/common-ui/dialog.ts
+++ b/frontend/src/common-ui/dialog.ts
@@ -58,6 +58,16 @@ export class Dialog extends BaseDialog {
     }
   }
 
+  showWrongItemDialog(npcId?: string): void {
+    if (!this.activeDialog || this.questGiverNpcId !== npcId) return;
+
+    const textWrongItem = this.selectRandomText(
+      this.activeDialog.questWrongItem,
+    );
+    this.messagesToShow = [...textWrongItem];
+    this.showNextMessage();
+  }
+
   getQuestGiverNpcId(): string | undefined {
     return this.questGiverNpcId;
   }

--- a/frontend/src/scenes/base-scene.ts
+++ b/frontend/src/scenes/base-scene.ts
@@ -323,7 +323,7 @@ export abstract class BaseScene extends Scene {
       if (this.heldItem!.texture.key === assetKey) {
         this.updateQuestProgress(npc);
       } else {
-        this.applyWrongItemPenalty();
+        this.applyWrongItemPenalty(npc);
       }
 
       this.heldItem!.destroy();
@@ -355,7 +355,9 @@ export abstract class BaseScene extends Scene {
     });
   }
 
-  private applyWrongItemPenalty(): void {
+  private applyWrongItemPenalty(npc: Phaser.GameObjects.Sprite): void {
+    this.dialog?.showWrongItemDialog(npc.name);
+
     const isDead = this.healthBar.decreaseHealth(30);
     if (isDead) {
       this.scene.start(SceneKeys.GAME_OVER);

--- a/frontend/src/types/level-data.d.ts
+++ b/frontend/src/types/level-data.d.ts
@@ -4,6 +4,7 @@ export type DialogData = {
   questStart: string[][];
   questInProgress: string[][];
   questFinished: string[][];
+  questWrongItem: string[][];
   hints: string[][];
   options: string[] | undefined;
   correctOption: string | undefined;
@@ -22,6 +23,8 @@ export type RawDialogData = {
   questInProgressIAGenerated: string[];
   questFinished: string[];
   questFinishedIAGenerated: string[];
+  questWrongItem: string[];
+  questWrongItemIAGenerated: string[];
   hints: string[];
   hintsIAGenerated: string[];
   options: string[] | undefined;

--- a/frontend/src/utils/data-util.ts
+++ b/frontend/src/utils/data-util.ts
@@ -22,6 +22,10 @@ export const loadLevelData = (
         (dialog.questFinished ?? []).filter(Boolean),
         (dialog.questFinishedIAGenerated ?? []).filter(Boolean),
       ],
+      questWrongItem: [
+        (dialog.questWrongItem ?? []).filter(Boolean),
+        (dialog.questWrongItemIAGenerated ?? []).filter(Boolean),
+      ],
       hints: [
         (dialog.hints ?? []).filter(Boolean),
         (dialog.hintsIAGenerated ?? []).filter(Boolean),


### PR DESCRIPTION
This pull request introduces a new feature to handle incorrect quest items in the game. The changes span across the backend, frontend, and data files to support this functionality.

### Backend Changes:
* Added a new dialog type `questWrongItem` to the `DIALOG_TYPES` array in `gemini_controller.py` to handle scenarios where the player provides an incorrect item.

### Frontend Changes:
* Updated `level_1.json` to include new dialog entries for `questWrongItem` and `questWrongItemIAGenerated` to provide feedback to the player when they present the wrong item.
* Added a new method `showWrongItemDialog` in `dialog.ts` to display the wrong item dialog to the player.
* Modified the `applyWrongItemPenalty` method in `base-scene.ts` to accept an `npc` parameter and show the wrong item dialog when the player provides an incorrect item.

### Data Handling Changes:
* Updated `data-util.ts` to load the new `questWrongItem` dialog data.