### PR TITLE
feat(awards): allow awards to change asset based on quest

### DIFF
--- a/frontend/public/assets/data/level_1.json
+++ b/frontend/public/assets/data/level_1.json
@@ -33,12 +33,15 @@
       "id": "d-2",
       "description": "segundo dialogo",
       "questStart": [
-        "My favorite fruits are apples!",
-        "Could you pick some for me?"
+        "My favorite fruits are bananas!",
+        "Could you pick two bananas for me?"
       ],
-      "questInProgress": [],
-      "questFinished": ["Thank you so much!"],
-      "hints": [],
+      "questWrongItem": ["That's not a banana!"],
+      "questInProgress": ["Hurry up! I need two bananas!"],
+      "questFinished": [
+        "Thank you so much! I'll make the best banana bread ever!"
+      ],
+      "hints": ["I'll give you a hint! Bananas are yellow and curved!"],
       "assetKey": "BANANAS",
       "quantityToCollect": 2
     },

--- a/frontend/public/assets/data/level_1.json
+++ b/frontend/public/assets/data/level_1.json
@@ -27,8 +27,7 @@
       ],
       "hintsIAGenerated": [""],
       "assetKey": "ORANGE",
-      "quantityToCollect": 1,
-      "disable": false
+      "quantityToCollect": 1
     },
     {
       "id": "d-2",
@@ -40,7 +39,8 @@
       "questInProgress": [],
       "questFinished": ["Thank you so much!"],
       "hints": [],
-      "disable": true
+      "assetKey": "BANANAS",
+      "quantityToCollect": 2
     },
     {
       "id": "dwo-1",

--- a/frontend/src/common-ui/awards.ts
+++ b/frontend/src/common-ui/awards.ts
@@ -51,7 +51,7 @@ export class Awards {
 
     this.scene = config.scene;
     this.assetKey = config.assetKey;
-    this.keyAnim = "AwardsKeyAnim";
+    this.keyAnim = `AwardsKeyAnim_${this.assetKey}`;
     this.positionX = AWARDS_CONFIG.POSITION_X;
     this.positionY = AWARDS_CONFIG.POSITION_Y;
     this.scale = AWARDS_CONFIG.SCALE;
@@ -79,7 +79,16 @@ export class Awards {
       this.removeAward(countDifference * -1);
     }
 
-    this.container.visible = this.sprites.length > 0;
+    this.container.visible = countDifference > 0;
+  }
+
+  destroy() {
+    this.sprites.forEach((sprite) => sprite.destroy());
+    if (this.container) {
+      this.container.removeAll(true);
+      this.container.destroy();
+    }
+    if (this.background) this.background.destroy();
   }
 
   private initializeUI(): void {

--- a/frontend/src/common-ui/dialog.ts
+++ b/frontend/src/common-ui/dialog.ts
@@ -47,14 +47,15 @@ export class Dialog extends BaseDialog {
     if (!this.activeDialog) return;
 
     if (this.questGiverNpcId === npcId) {
-      this.activeDialog!.completed = true;
-      this.questGiverNpcId = undefined;
-
       const textFinished = this.selectRandomText(
         this.activeDialog.questFinished,
       );
       this.messagesToShow = [...textFinished];
       this.showNextMessage();
+
+      this.activeDialog!.completed = true;
+      this.questGiverNpcId = undefined;
+      this.activeDialog = undefined;
     }
   }
 

--- a/frontend/src/scenes/base-scene.ts
+++ b/frontend/src/scenes/base-scene.ts
@@ -45,8 +45,6 @@ export abstract class BaseScene extends Scene {
 
   protected heldItem?: Phaser.GameObjects.Sprite;
 
-  protected remainingQuestItems = 0;
-
   // =========================================================================
   // Abstract Methods
   // =========================================================================
@@ -192,6 +190,8 @@ export abstract class BaseScene extends Scene {
   }
 
   private initializeAwards(assetKey: string, quantity: number): void {
+    if (quantity === 0) return;
+
     if (this.awards) {
       this.awards.destroy();
     }
@@ -204,6 +204,7 @@ export abstract class BaseScene extends Scene {
         this.awards = new Awards({
           scene: this,
           assetKey,
+          quantity,
           spriteConfig: {
             startFrame: ItemKeys.FRUITS[fruitKey].STAR_FRAME,
             endFrame: ItemKeys.FRUITS[fruitKey].END_FRAME,
@@ -213,8 +214,6 @@ export abstract class BaseScene extends Scene {
         });
       }
     }
-
-    this.awards.setAwardsCount(quantity);
   }
 
   private pickupItem(item: Phaser.GameObjects.Sprite): void {
@@ -303,7 +302,7 @@ export abstract class BaseScene extends Scene {
           npcSprite.y,
         );
 
-        if (distance <= 50) {
+        if (distance <= 80) {
           this.handleInteractionNPC(npcSprite);
         }
       });
@@ -327,7 +326,6 @@ export abstract class BaseScene extends Scene {
     const assetKey = this.dialog?.getAssetKey();
 
     if (!assetKey) return;
-
     this.initializeAwards(assetKey, this.dialog?.getQuantityToCollect() || 0);
     this.showElements(assetKey);
   }
@@ -350,10 +348,8 @@ export abstract class BaseScene extends Scene {
   }
 
   private updateQuestProgress(npc: Phaser.GameObjects.Sprite): void {
-    this.remainingQuestItems -= 1;
-    this.awards.setAwardsCount(this.remainingQuestItems);
-
-    if (this.remainingQuestItems === 0) {
+    const quantity = this.awards.removeAward();
+    if (quantity === 0) {
       this.dialog?.setMessageComplete(npc.name);
 
       if (this.dialog?.areAllDialogsCompleted()) {

--- a/frontend/src/scenes/level1.ts
+++ b/frontend/src/scenes/level1.ts
@@ -40,7 +40,7 @@ export const level1Config: TileConfig[] = [
       type: TileType.OBSTACLE,
       asset: TileKeys.TREE,
     },
-    frequency: 100,
+    frequency: 1,
   },
   {
     tile: {

--- a/frontend/src/scenes/level1.ts
+++ b/frontend/src/scenes/level1.ts
@@ -56,6 +56,13 @@ export const level1Config: TileConfig[] = [
     },
     frequency: 5,
   },
+  {
+    tile: {
+      type: TileType.INTERACTIVE_OBJECT,
+      asset: ItemKeys.FRUITS.BANANAS.ASSET_KEY,
+    },
+    frequency: 10,
+  },
 ];
 
 export class Level1 extends BaseScene {
@@ -71,11 +78,13 @@ export class Level1 extends BaseScene {
     await super.create();
 
     this.hideElements(ItemKeys.FRUITS.ORANGE.ASSET_KEY);
+    this.hideElements(ItemKeys.FRUITS.BANANAS.ASSET_KEY);
   }
 
   protected createAnimations(): void {
     Animations.useOrangeAnimation(this);
     Animations.useStrawberryAnimation(this);
+    Animations.useBananasAnimation(this);
   }
 
   protected setupCollisions(): void {
@@ -83,5 +92,6 @@ export class Level1 extends BaseScene {
 
     this.makeItemDraggable(ItemKeys.FRUITS.ORANGE.ASSET_KEY);
     this.makeItemDraggable(ItemKeys.FRUITS.STRAWBERRY.ASSET_KEY);
+    this.makeItemDraggable(ItemKeys.FRUITS.BANANAS.ASSET_KEY);
   }
 }


### PR DESCRIPTION
This pull request includes several changes to the frontend and backend of the game, focusing on adding new fruit items, updating dialog content, and improving the game mechanics. The most important changes include adding new fruit items, enhancing dialog options, and refining game behavior.

### New Fruit Items:

* [`frontend/src/assets/asset-keys.ts`](diffhunk://#diff-3890cb02573c53f52c8c967019efe175c5412fec85012effb6f277c753e409f5L63-R108): Added new fruit items including `APPLE`, `BANANAS`, `CHERRIES`, `KIWI`, `MELON`, and `PINEAPPLE` with their respective animation keys and frame configurations. [[1]](diffhunk://#diff-3890cb02573c53f52c8c967019efe175c5412fec85012effb6f277c753e409f5L63-R108) [[2]](diffhunk://#diff-3890cb02573c53f52c8c967019efe175c5412fec85012effb6f277c753e409f5R117-R124)
* [`frontend/src/scenes/preloader.ts`](diffhunk://#diff-1f0eaf97b83a31b59a98836daf4caa6878e135d38fd6106e6e99e4a2f93feac7L86-R90): Refactored the preloader to load all new fruit items using a new `loadFruits` method. [[1]](diffhunk://#diff-1f0eaf97b83a31b59a98836daf4caa6878e135d38fd6106e6e99e4a2f93feac7L86-R90) [[2]](diffhunk://#diff-1f0eaf97b83a31b59a98836daf4caa6878e135d38fd6106e6e99e4a2f93feac7R127-R209)

### Dialog Enhancements:

* [`frontend/public/assets/data/level_1.json`](diffhunk://#diff-0c454196904c49d69582deb3bfd4c3a78944610e85507364652c43e9d8541bacL9-R30): Updated dialog content to include new responses for `questStart`, `questInProgress`, and added a new `questWrongItem` dialog. [[1]](diffhunk://#diff-0c454196904c49d69582deb3bfd4c3a78944610e85507364652c43e9d8541bacL9-R30) [[2]](diffhunk://#diff-0c454196904c49d69582deb3bfd4c3a78944610e85507364652c43e9d8541bacL39-R43)
* [`frontend/src/common-ui/dialog.ts`](diffhunk://#diff-caaa4ef0ec4c2308b7fa622dc1e842e87ef8344238f1a056bad2c5251304d655R50-R71): Added a method `showWrongItemDialog` to handle incorrect item submissions during quests.

### Game Mechanic Improvements:

* [`frontend/src/common-ui/awards.ts`](diffhunk://#diff-e024cf6b80074b60791b6d3ffe481c7b934b4b5648e65a1fee652f2584708becL54-R54): Modified the `Awards` class to use dynamic animation keys and added a `destroy` method to clean up resources. [[1]](diffhunk://#diff-e024cf6b80074b60791b6d3ffe481c7b934b4b5648e65a1fee652f2584708becL54-R54) [[2]](diffhunk://#diff-e024cf6b80074b60791b6d3ffe481c7b934b4b5648e65a1fee652f2584708becL82-R91)
* [`frontend/src/scenes/base-scene.ts`](diffhunk://#diff-ebb4d342a85838a95354d7a8097af326b4d20a99f7868a9904c3f01366d34d35L157): Refined the `initializeAwards` method to handle different fruit items and adjusted the interaction distance for NPCs. [[1]](diffhunk://#diff-ebb4d342a85838a95354d7a8097af326b4d20a99f7868a9904c3f01366d34d35L157) [[2]](diffhunk://#diff-ebb4d342a85838a95354d7a8097af326b4d20a99f7868a9904c3f01366d34d35L289-R306) [[3]](diffhunk://#diff-ebb4d342a85838a95354d7a8097af326b4d20a99f7868a9904c3f01366d34d35L314-R331) [[4]](diffhunk://#diff-ebb4d342a85838a95354d7a8097af326b4d20a99f7868a9904c3f01366d34d35L326-R342) [[5]](diffhunk://#diff-ebb4d342a85838a95354d7a8097af326b4d20a99f7868a9904c3f01366d34d35L342-R379) [[6]](diffhunk://#diff-ebb4d342a85838a95354d7a8097af326b4d20a99f7868a9904c3f01366d34d35R398-R412)

### Visual and UI Updates:

* [`frontend/src/assets/colors.ts`](diffhunk://#diff-d40dcfd9bfb09aa34015ce1953cc67cd6af3ed6b342771a6daa7d42de2c661abL6-R6): Changed the main dialog color to white (`0xffffff`).
* [`frontend/src/common/map/map-renderer.ts`](diffhunk://#diff-a5a09371f4586d39be57c660295644adbf04d10855900a9045c53b582dfce595L105-R105): Updated sprite naming convention to include frame information.

### Code Refactoring:

* [`frontend/src/scenes/base-scene.ts`](diffhunk://#diff-ebb4d342a85838a95354d7a8097af326b4d20a99f7868a9904c3f01366d34d35L20-R25): Reintroduced the `validateMapConfig` method to ensure map configuration integrity. [[1]](diffhunk://#diff-ebb4d342a85838a95354d7a8097af326b4d20a99f7868a9904c3f01366d34d35L20-R25) [[2]](diffhunk://#diff-ebb4d342a85838a95354d7a8097af326b4d20a99f7868a9904c3f01366d34d35L190-R218)