### PR TITLE
fix(dialogs): remove empty dialog entries to prevent blank lines

### DIFF
--- a/frontend/src/scenes/base-scene.ts
+++ b/frontend/src/scenes/base-scene.ts
@@ -232,7 +232,6 @@ export abstract class BaseScene extends Scene {
       return;
     }
 
-    console.log("second hit. Im in the handlePlayerInteraction");
     this.interactWithNearNPC();
 
     if (this.heldItem) {
@@ -317,7 +316,6 @@ export abstract class BaseScene extends Scene {
     if (this.heldItem) {
       this.handleItemInteraction(npc);
     } else {
-      console.log("fifth hit. Im in the handleInteractionNPC");
       this.dialog?.show(npc.name);
     }
   }

--- a/frontend/src/scenes/base-scene.ts
+++ b/frontend/src/scenes/base-scene.ts
@@ -80,8 +80,7 @@ export abstract class BaseScene extends Scene {
       return;
     }
 
-    const directionSelected = this.controls.getDirectionKeyPressed();
-    this.player.move(directionSelected);
+    this.player.move(this.controls.getDirectionKeyPressed());
 
     if (this.heldItem) {
       this.heldItem.setPosition(this.player.x, this.player.y);
@@ -233,6 +232,7 @@ export abstract class BaseScene extends Scene {
       return;
     }
 
+    console.log("second hit. Im in the handlePlayerInteraction");
     this.interactWithNearNPC();
 
     if (this.heldItem) {
@@ -302,7 +302,7 @@ export abstract class BaseScene extends Scene {
           npcSprite.y,
         );
 
-        if (distance <= 80) {
+        if (distance <= 70) {
           this.handleInteractionNPC(npcSprite);
         }
       });
@@ -317,6 +317,7 @@ export abstract class BaseScene extends Scene {
     if (this.heldItem) {
       this.handleItemInteraction(npc);
     } else {
+      console.log("fifth hit. Im in the handleInteractionNPC");
       this.dialog?.show(npc.name);
     }
   }

--- a/frontend/src/utils/data-util.ts
+++ b/frontend/src/utils/data-util.ts
@@ -1,5 +1,8 @@
 import type { DialogData, LevelData, RawDialogData } from "types/level-data";
 
+const isNotEmpty = (arr: string[]): boolean =>
+  arr.length > 0 && arr.some((t) => t.trim().length > 0);
+
 export const loadLevelData = (
   scene: Phaser.Scene,
   level: string,
@@ -11,25 +14,24 @@ export const loadLevelData = (
       id: dialog.id,
       description: dialog.description,
       questStart: [
-        (dialog.questStart ?? []).filter(Boolean),
-        (dialog.questStartIAGenerated ?? []).filter(Boolean),
-      ],
+        dialog.questStart ?? [],
+        dialog.questStartIAGenerated ?? [],
+      ].filter(isNotEmpty),
       questInProgress: [
-        (dialog.questInProgress ?? []).filter(Boolean),
-        (dialog.questInProgressIAGenerated ?? []).filter(Boolean),
-      ],
+        dialog.questInProgress ?? [],
+        dialog.questInProgressIAGenerated ?? [],
+      ].filter(isNotEmpty),
       questFinished: [
-        (dialog.questFinished ?? []).filter(Boolean),
-        (dialog.questFinishedIAGenerated ?? []).filter(Boolean),
-      ],
+        dialog.questFinished ?? [],
+        dialog.questFinishedIAGenerated ?? [],
+      ].filter(isNotEmpty),
       questWrongItem: [
-        (dialog.questWrongItem ?? []).filter(Boolean),
-        (dialog.questWrongItemIAGenerated ?? []).filter(Boolean),
-      ],
-      hints: [
-        (dialog.hints ?? []).filter(Boolean),
-        (dialog.hintsIAGenerated ?? []).filter(Boolean),
-      ],
+        dialog.questWrongItem ?? [],
+        dialog.questWrongItemIAGenerated ?? [],
+      ].filter(isNotEmpty),
+      hints: [dialog.hints ?? [], dialog.hintsIAGenerated ?? []].filter(
+        isNotEmpty,
+      ),
       options: dialog.options,
       correctOption: dialog.correctOption,
       assetKey: dialog.assetKey,


### PR DESCRIPTION
This pull request includes several changes to the `frontend/src/scenes/base-scene.ts` and `frontend/src/utils/data-util.ts` files. The main focus is on code simplification and adding debugging information. Below is a summary of the most important changes:

Code simplification and debugging:

* Simplified the `move` method call by directly passing the result of `this.controls.getDirectionKeyPressed()` as an argument in `BaseScene`.
* Added console logs for debugging purposes in the `handlePlayerInteraction` and `handleInteractionNPC` methods in `BaseScene`. [[1]](diffhunk://#diff-ebb4d342a85838a95354d7a8097af326b4d20a99f7868a9904c3f01366d34d35R235) [[2]](diffhunk://#diff-ebb4d342a85838a95354d7a8097af326b4d20a99f7868a9904c3f01366d34d35R320)
* Adjusted the interaction distance from 80 to 70 units in the `BaseScene` class.

Utility function enhancements:

* Added a new utility function `isNotEmpty` to check for non-empty arrays in `data-util.ts`.
* Refactored the `loadLevelData` function to use the `isNotEmpty` utility function for filtering dialog arrays.