### PR TITLE
fix: interactable objects now use 'quantity' property instead of 'frequency'

### DIFF
--- a/frontend/src/common/map/map-generator.ts
+++ b/frontend/src/common/map/map-generator.ts
@@ -67,33 +67,33 @@ export class MapGenerator {
     );
     map.initialParameters = config;
 
-    const rootPartition = this.createPartitions(
-      {
-        x: 0,
-        y: 0,
-        width: config.mapWidth,
-        height: config.mapHeight,
-      },
-      config.minPartitionSize,
-    );
-    this.assignRooms(rootPartition, config.minRoomSize);
+  const rootPartition = this.createPartitions(
+    {
+      x: 0,
+      y: 0,
+      width: config.mapWidth,
+      height: config.mapHeight,
+    },
+    config.minPartitionSize,
+  );
+      this.assignRooms(rootPartition, config.minRoomSize);
 
-    const matrix = new Array(config.mapWidth)
+      const matrix = new Array(config.mapWidth)
       .fill([])
       .map(() => new Array(config.mapHeight).fill(UNUSED_CELL));
-
-    this.fillAndConnectRooms(matrix, rootPartition);
-    this.assignTiles(map, matrix, config.tilesConfig);
-
-    const privateStaticObjects = config.tilesConfig.filter(
-      (t) => t.tile.type === TileType.INTERACTIVE_STATIC_OBJECT,
-    );
-    this.assignInteractiveStaticObject(
-      map,
-      rootPartition,
-      privateStaticObjects,
-    );
-
+      
+      this.fillAndConnectRooms(matrix, rootPartition);
+      this.assignTiles(map, matrix, config.tilesConfig);
+      
+      const privateStaticObjects = config.tilesConfig.filter(
+        (t) => t.tile.type === TileType.INTERACTIVE_STATIC_OBJECT,
+      );
+      this.assignInteractiveStaticObject(
+        map,
+        rootPartition,
+        privateStaticObjects,
+      );
+    
     return map;
   }
 
@@ -335,9 +335,9 @@ export class MapGenerator {
             new Array(unusedCells.length).fill(1),
             unusedCells,
           );
-          const [x, y] = position;
+          const [y, x] = position;
 
-          map.tiles[x]![y] = interactiveQuantityTiles.tiles[index]!;
+          map.tiles[y]![x] = interactiveQuantityTiles.tiles[index]!;
 
           const idx = unusedCells.findIndex(([j, k]) => j === y && k === x);
           if (idx !== -1) unusedCells.splice(idx, 1);

--- a/frontend/src/common/map/map-generator.ts
+++ b/frontend/src/common/map/map-generator.ts
@@ -67,33 +67,33 @@ export class MapGenerator {
     );
     map.initialParameters = config;
 
-  const rootPartition = this.createPartitions(
-    {
-      x: 0,
-      y: 0,
-      width: config.mapWidth,
-      height: config.mapHeight,
-    },
-    config.minPartitionSize,
-  );
-      this.assignRooms(rootPartition, config.minRoomSize);
+    const rootPartition = this.createPartitions(
+      {
+        x: 0,
+        y: 0,
+        width: config.mapWidth,
+        height: config.mapHeight,
+      },
+      config.minPartitionSize,
+    );
+    this.assignRooms(rootPartition, config.minRoomSize);
 
-      const matrix = new Array(config.mapWidth)
+    const matrix = new Array(config.mapWidth)
       .fill([])
       .map(() => new Array(config.mapHeight).fill(UNUSED_CELL));
-      
-      this.fillAndConnectRooms(matrix, rootPartition);
-      this.assignTiles(map, matrix, config.tilesConfig);
-      
-      const privateStaticObjects = config.tilesConfig.filter(
-        (t) => t.tile.type === TileType.INTERACTIVE_STATIC_OBJECT,
-      );
-      this.assignInteractiveStaticObject(
-        map,
-        rootPartition,
-        privateStaticObjects,
-      );
-    
+
+    this.fillAndConnectRooms(matrix, rootPartition);
+    this.assignTiles(map, matrix, config.tilesConfig);
+
+    const privateStaticObjects = config.tilesConfig.filter(
+      (t) => t.tile.type === TileType.INTERACTIVE_STATIC_OBJECT,
+    );
+    this.assignInteractiveStaticObject(
+      map,
+      rootPartition,
+      privateStaticObjects,
+    );
+
     return map;
   }
 

--- a/frontend/src/common/map/map-generator.ts
+++ b/frontend/src/common/map/map-generator.ts
@@ -390,7 +390,7 @@ export class MapGenerator {
     for (let i = 0; i < frequencies.length; i += 1) {
       cumulative += frequencies[i]!;
       if (randomValue < cumulative) {
-        return tiles[i]!; // Starts in 3
+        return tiles[i]!;
       }
     }
 

--- a/frontend/src/common/map/map-generator.ts
+++ b/frontend/src/common/map/map-generator.ts
@@ -4,7 +4,6 @@ import {
   type MapConfiguration,
   type TileConfig,
   type MapStructure,
-  type Tile,
 } from "types/map.d";
 
 type Room = {
@@ -137,8 +136,8 @@ export class MapGenerator {
     if (splitHorizontally) {
       const splitY = Math.floor(
         Math.random() * (height - 2 * minPartitionSize) +
-        partition.y +
-        minPartitionSize,
+          partition.y +
+          minPartitionSize,
       );
       left = {
         x: partition.x,
@@ -155,8 +154,8 @@ export class MapGenerator {
     } else {
       const splitX = Math.floor(
         Math.random() * (partition.width - 2 * minPartitionSize) +
-        partition.x +
-        minPartitionSize,
+          partition.x +
+          minPartitionSize,
       );
       left = {
         x: partition.x,
@@ -295,8 +294,11 @@ export class MapGenerator {
     matrix: number[][],
     tilesConfig: TileConfig[],
   ): void {
-    const [interactivefrequencyTiles, obstaclefrequencyTiles, interactiveQuantityTiles] =
-      this.prepareTileConfigs(tilesConfig);
+    const [
+      interactivefrequencyTiles,
+      obstaclefrequencyTiles,
+      interactiveQuantityTiles,
+    ] = this.prepareTileConfigs(tilesConfig);
 
     matrix.forEach((row, rowIndex) => {
       row.forEach((element, columnIndex) => {
@@ -371,10 +373,9 @@ export class MapGenerator {
         tiles: obstacleTiles.map((m) => m.tile),
       },
       {
-
-        quantities: interactiveQuantityTiles.map((m) => (m.quantity || 0)),
-        tiles: interactiveQuantityTiles.map((m) => (m.tile))
-      }
+        quantities: interactiveQuantityTiles.map((m) => m.quantity || 0),
+        tiles: interactiveQuantityTiles.map((m) => m.tile),
+      },
     ];
   }
 

--- a/frontend/src/common/map/map-generator.ts
+++ b/frontend/src/common/map/map-generator.ts
@@ -4,6 +4,7 @@ import {
   type MapConfiguration,
   type TileConfig,
   type MapStructure,
+  type Tile,
 } from "types/map.d";
 
 type Room = {
@@ -294,40 +295,65 @@ export class MapGenerator {
     matrix: number[][],
     tilesConfig: TileConfig[],
   ): void {
-    const [interactiveTiles, obstacleTiles] =
-      this.prepareTileConfigs(tilesConfig);
-
-    matrix.forEach((column, columnIndex) => {
-      column.forEach((element, rowIndex) => {
+    const [interactiveFrecuencyTiles, obstacleFrecuencyTiles] =
+      this.prepareTileBasedOnFrecuencyConfigs(tilesConfig);
+  
+    matrix.forEach((row, rowIndex) => {
+      row.forEach((element, columnIndex) => {
         if (element === USED_CELL) {
-          map.tiles[columnIndex]![rowIndex] = this.getTileBasedOnFrequency(
-            interactiveTiles!.frequencies,
-            interactiveTiles!.tiles,
+          map.tiles[rowIndex]![columnIndex] = this.getTileBasedOnFrequency(
+            interactiveFrecuencyTiles!.frequencies,
+            interactiveFrecuencyTiles!.tiles,
           );
           if (map.startPosition.x === 0 && map.startPosition.y === 0) {
             map.startPosition.x = columnIndex + 1;
             map.startPosition.y = rowIndex + 1;
           }
-        }
-        if (element === UNUSED_CELL) {
-          map.tiles[columnIndex]![rowIndex] = this.getTileBasedOnFrequency(
-            obstacleTiles!.frequencies,
-            obstacleTiles!.tiles,
+        } else if (element === UNUSED_CELL) {
+          map.tiles[rowIndex]![columnIndex] = this.getTileBasedOnFrequency(
+            obstacleFrecuencyTiles!.frequencies,
+            obstacleFrecuencyTiles!.tiles,
           );
         }
       });
     });
+  
+    const interactiveQuantityTiles =
+      this.prepareTileBasedOnQuantityConfigs(tilesConfig);
+  
+    const unusedCells = matrix.flatMap((fila, i) =>
+      fila.map((valor, j) => (valor === USED_CELL ? [i, j] : null))
+    ).filter(Boolean) as [number, number][];
+  
+    (interactiveQuantityTiles).forEach((interactiveObject: { Quantity: number; Tile: Tile; }) => {
+      for (let i = 0; i < interactiveObject.Quantity; i++) {
+        if (unusedCells.length === 0) break;
+  
+        const position = this.getTileBasedOnFrequency(
+          new Array(unusedCells.length).fill(1),
+          unusedCells,
+        );
+        const [y, x] = position;
+  
+        map.tiles[y]![x] = interactiveObject.Tile;
+  
+        const idx = unusedCells.findIndex(([i, j]) => i === y && j === x);
+        if (idx !== -1) unusedCells.splice(idx, 1);
+      }
+    });
   }
+  
 
-  private static prepareTileConfigs(tilesConfig: TileConfig[]) {
+  private static prepareTileBasedOnFrecuencyConfigs(tilesConfig: TileConfig[]) {
     const interactiveTiles = tilesConfig.filter(
       (f) =>
+        f.frequency &&
         f.tile.type === TileType.INTERACTIVE_OBJECT ||
         f.tile.type === TileType.WALKABLE_SPACE,
     );
 
     const obstacleTiles = tilesConfig.filter(
-      (f) => f.tile.type === TileType.OBSTACLE,
+      (f) => f.frequency && f.tile.type === TileType.OBSTACLE,
     );
 
     return [
@@ -340,6 +366,21 @@ export class MapGenerator {
         tiles: obstacleTiles.map((m) => m.tile),
       },
     ];
+  }
+
+  private static prepareTileBasedOnQuantityConfigs(tilesConfig: TileConfig[]) {
+    const interactiveTiles = tilesConfig.filter(
+      (f) =>
+        f.quantity &&
+        f.tile.type === TileType.INTERACTIVE_OBJECT ||
+        f.tile.type === TileType.WALKABLE_SPACE,
+    );
+
+    const obstacleTiles = tilesConfig.filter(
+      (f) => f.frequency && f.tile.type === TileType.OBSTACLE,
+    );
+
+    return interactiveTiles.map((m) => ({ Quantity: m.quantity || 0, Tile: m.tile }));
   }
 
   private static getTileBasedOnFrequency<T>(

--- a/frontend/src/common/map/map-generator.ts
+++ b/frontend/src/common/map/map-generator.ts
@@ -297,7 +297,7 @@ export class MapGenerator {
     const [
       interactivefrequencyTiles,
       obstaclefrequencyTiles,
-      interactiveQuantityTiles,
+      fixedQuantityInteractiveTiles,
     ] = this.prepareTileConfigs(tilesConfig);
 
     matrix.forEach((row, rowIndex) => {
@@ -326,7 +326,7 @@ export class MapGenerator {
       )
       .filter(Boolean) as [number, number][];
 
-    interactiveQuantityTiles?.quantities!.forEach(
+    fixedQuantityInteractiveTiles?.quantities!.forEach(
       (interactiveObject, index) => {
         for (let i = 0; i < interactiveObject; i += 1) {
           if (unusedCells.length === 0) break;
@@ -337,7 +337,7 @@ export class MapGenerator {
           );
           const [y, x] = position;
 
-          map.tiles[y]![x] = interactiveQuantityTiles.tiles[index]!;
+          map.tiles[y]![x] = fixedQuantityInteractiveTiles.tiles[index]!;
 
           const idx = unusedCells.findIndex(([j, k]) => j === y && k === x);
           if (idx !== -1) unusedCells.splice(idx, 1);
@@ -357,7 +357,7 @@ export class MapGenerator {
       (f) => f.frequency && f.tile.type === TileType.OBSTACLE,
     );
 
-    const interactiveQuantityTiles = tilesConfig.filter(
+    const fixedQuantityInteractiveTiles = tilesConfig.filter(
       (f) =>
         (f.quantity && f.tile.type === TileType.INTERACTIVE_OBJECT) ||
         f.tile.type === TileType.WALKABLE_SPACE,
@@ -373,8 +373,8 @@ export class MapGenerator {
         tiles: obstacleTiles.map((m) => m.tile),
       },
       {
-        quantities: interactiveQuantityTiles.map((m) => m.quantity || 0),
-        tiles: interactiveQuantityTiles.map((m) => m.tile),
+        quantities: fixedQuantityInteractiveTiles.map((m) => m.quantity || 0),
+        tiles: fixedQuantityInteractiveTiles.map((m) => m.tile),
       },
     ];
   }

--- a/frontend/src/common/map/map-generator.ts
+++ b/frontend/src/common/map/map-generator.ts
@@ -297,7 +297,7 @@ export class MapGenerator {
   ): void {
     const [interactiveFrecuencyTiles, obstacleFrecuencyTiles] =
       this.prepareTileBasedOnFrecuencyConfigs(tilesConfig);
-  
+
     matrix.forEach((row, rowIndex) => {
       row.forEach((element, columnIndex) => {
         if (element === USED_CELL) {
@@ -317,38 +317,40 @@ export class MapGenerator {
         }
       });
     });
-  
+
     const interactiveQuantityTiles =
       this.prepareTileBasedOnQuantityConfigs(tilesConfig);
-  
-    const unusedCells = matrix.flatMap((fila, i) =>
-      fila.map((valor, j) => (valor === USED_CELL ? [i, j] : null))
-    ).filter(Boolean) as [number, number][];
-  
-    (interactiveQuantityTiles).forEach((interactiveObject: { Quantity: number; Tile: Tile; }) => {
-      for (let i = 0; i < interactiveObject.Quantity; i++) {
-        if (unusedCells.length === 0) break;
-  
-        const position = this.getTileBasedOnFrequency(
-          new Array(unusedCells.length).fill(1),
-          unusedCells,
-        );
-        const [y, x] = position;
-  
-        map.tiles[y]![x] = interactiveObject.Tile;
-  
-        const idx = unusedCells.findIndex(([i, j]) => i === y && j === x);
-        if (idx !== -1) unusedCells.splice(idx, 1);
-      }
-    });
+
+    const unusedCells = matrix
+      .flatMap((fila, i) =>
+        fila.map((valor, j) => (valor === USED_CELL ? [i, j] : null)),
+      )
+      .filter(Boolean) as [number, number][];
+
+    interactiveQuantityTiles.forEach(
+      (interactiveObject: { Quantity: number; Tile: Tile }) => {
+        for (let i = 0; i < interactiveObject.Quantity; i += 1) {
+          if (unusedCells.length === 0) break;
+
+          const position = this.getTileBasedOnFrequency(
+            new Array(unusedCells.length).fill(1),
+            unusedCells,
+          );
+          const [y, x] = position;
+
+          map.tiles[y]![x] = interactiveObject.Tile;
+
+          const idx = unusedCells.findIndex(([j, k]) => j === y && k === x);
+          if (idx !== -1) unusedCells.splice(idx, 1);
+        }
+      },
+    );
   }
-  
 
   private static prepareTileBasedOnFrecuencyConfigs(tilesConfig: TileConfig[]) {
     const interactiveTiles = tilesConfig.filter(
       (f) =>
-        f.frequency &&
-        f.tile.type === TileType.INTERACTIVE_OBJECT ||
+        (f.frequency && f.tile.type === TileType.INTERACTIVE_OBJECT) ||
         f.tile.type === TileType.WALKABLE_SPACE,
     );
 
@@ -371,16 +373,14 @@ export class MapGenerator {
   private static prepareTileBasedOnQuantityConfigs(tilesConfig: TileConfig[]) {
     const interactiveTiles = tilesConfig.filter(
       (f) =>
-        f.quantity &&
-        f.tile.type === TileType.INTERACTIVE_OBJECT ||
+        (f.quantity && f.tile.type === TileType.INTERACTIVE_OBJECT) ||
         f.tile.type === TileType.WALKABLE_SPACE,
     );
 
-    const obstacleTiles = tilesConfig.filter(
-      (f) => f.frequency && f.tile.type === TileType.OBSTACLE,
-    );
-
-    return interactiveTiles.map((m) => ({ Quantity: m.quantity || 0, Tile: m.tile }));
+    return interactiveTiles.map((m) => ({
+      Quantity: m.quantity || 0,
+      Tile: m.tile,
+    }));
   }
 
   private static getTileBasedOnFrequency<T>(

--- a/frontend/src/scenes/level1.ts
+++ b/frontend/src/scenes/level1.ts
@@ -47,7 +47,7 @@ export const level1Config: TileConfig[] = [
       type: TileType.INTERACTIVE_OBJECT,
       asset: ItemKeys.FRUITS.ORANGE.ASSET_KEY,
     },
-    frequency: 2,
+    quantity: 1,
   },
   {
     tile: {
@@ -61,7 +61,7 @@ export const level1Config: TileConfig[] = [
       type: TileType.INTERACTIVE_OBJECT,
       asset: ItemKeys.FRUITS.BANANAS.ASSET_KEY,
     },
-    frequency: 10,
+    quantity: 2,
   },
 ];
 


### PR DESCRIPTION
This pull request includes significant updates to the `MapGenerator` class in the `frontend/src/common/map/map-generator.ts` file, focusing on how tiles are prepared and placed on the map. Additionally, it modifies the tile configuration in the `frontend/src/scenes/level1.ts` file to use quantity instead of frequency for certain tiles.

Changes to `MapGenerator` class:

* Renamed the method `prepareTileConfigs` to `prepareTileBasedOnFrecuencyConfigs` and updated its logic to handle frequency-based tile preparation.
* Introduced a new method `prepareTileBasedOnQuantityConfigs` to handle quantity-based tile preparation.
* Updated the main tile placement logic to use both frequency and quantity configurations, ensuring tiles are placed based on their respective configurations.

Changes to tile configuration in `level1.ts`:

* Updated `level1Config` to use `quantity` instead of `frequency` for certain interactive object tiles. [[1]](diffhunk://#diff-ef8fc8a455c1f522657183928990122aa78d1420b2b071feed09dabeae357eb2L50-R50) [[2]](diffhunk://#diff-ef8fc8a455c1f522657183928990122aa78d1420b2b071feed09dabeae357eb2L64-R64)