### PR TITLE
fix: correct NPC positions

### DIFF
--- a/frontend/src/common/map/map-generator.ts
+++ b/frontend/src/common/map/map-generator.ts
@@ -376,8 +376,8 @@ export class MapGenerator {
 
         rooms.splice(rooms.indexOf(room), 1);
 
-        map.tiles[room.x + Math.trunc(room.width / 2)]![
-          room.y + Math.trunc(room.height / 2)
+        map.tiles[room.y + Math.floor(room.width / 2)]![
+          room.x + Math.floor(room.height / 2)
         ] = tile.tile;
       }
     });


### PR DESCRIPTION
This pull request includes a small but critical change to the `MapGenerator` class in the `map-generator.ts` file. The change corrects the indexing of map tiles by swapping the `x` and `y` coordinates in the assignment operation to ensure the tiles are placed correctly.

* [`frontend/src/common/map/map-generator.ts`](diffhunk://#diff-1bcc263357462c30729dae65b03cd702205d7c5e174325e346c4feef0c4958abL379-R380): Corrected the indexing of map tiles by swapping the `x` and `y` coordinates in the assignment operation to ensure proper placement of tiles.