### PR TITLE
fix: correct percent calculation for health bar

### DIFF
--- a/frontend/src/common-ui/health-bar.ts
+++ b/frontend/src/common-ui/health-bar.ts
@@ -95,23 +95,25 @@ export class HealthBar {
 
   private setFillBarPercentage(percent = 1): void {
     const width = this.originalWidth * percent;
-    if (percent < 0.01) {
+    if (percent < 0.25) {
       this.scene.tweens.add({
         targets: this.fillBarRight,
         displayWidth: 0,
         duration: HEALTH_BAR_CONFIG.TWEEN_DURATION,
         ease: Phaser.Math.Easing.Sine.InOut,
       });
-      this.scene.tweens.add({
-        targets: this.fillBarLeft,
-        displayWidth: 0,
-        duration: HEALTH_BAR_CONFIG.TWEEN_DURATION,
-        ease: Phaser.Math.Easing.Sine.InOut,
-      });
+      if (percent === 0) {
+        this.scene.tweens.add({
+          targets: this.fillBarLeft,
+          displayWidth: 0,
+          duration: HEALTH_BAR_CONFIG.TWEEN_DURATION,
+          ease: Phaser.Math.Easing.Sine.InOut,
+        });
+      }
     } else
       this.scene.tweens.add({
         targets: this.fillBarRight,
-        displayWidth: width,
+        displayWidth: width * 0.75,
         duration: HEALTH_BAR_CONFIG.TWEEN_DURATION,
         ease: Phaser.Math.Easing.Sine.InOut,
       });


### PR DESCRIPTION
This pull request includes a change to the `HealthBar` class in the `frontend/src/common-ui/health-bar.ts` file to improve the visual representation of the health bar when the health percentage is low.

Improvements to health bar behavior:

* [`frontend/src/common-ui/health-bar.ts`](diffhunk://#diff-b1e775f19a33c126cbdbbfe9bb2a97d4e3c2922595ffad64255572d8a6328fcaL98-R116): Adjusted the condition to start shrinking the health bar when the percentage is below 25% instead of 1%, and added logic to set the left fill bar's width to 0 when the health percentage reaches 0.