### PR TITLE
fix: adjust start position margin

### DIFF
--- a/frontend/src/common/map/map-generator.ts
+++ b/frontend/src/common/map/map-generator.ts
@@ -344,9 +344,16 @@ export class MapGenerator {
   }
 
   private static calculateStartPosition(map: MapStructure) {
+    const startPositionMargin = { x: 2, y: 5 };
+
     const result = map.tiles
       .flatMap((row, y) => row.map((tile, x) => ({ tile, x, y })))
-      .find(({ tile }) => tile.type === TileType.WALKABLE_SPACE);
+      .find(
+        ({ tile, x, y }) =>
+          x >= startPositionMargin.x &&
+          y >= startPositionMargin.y &&
+          tile.type === TileType.WALKABLE_SPACE,
+      );
     if (!result) {
       throw new Error("No walkable space found for start position");
     }


### PR DESCRIPTION
This pull request makes a small but important improvement to the `MapGenerator` class in `frontend/src/common/map/map-generator.ts`. The change introduces a margin constraint when calculating the start position for a map, ensuring that the starting point is not too close to the map's edges.

* [`frontend/src/common/map/map-generator.ts`](diffhunk://#diff-1bcc263357462c30729dae65b03cd702205d7c5e174325e346c4feef0c4958abR347-R356): Added a `startPositionMargin` object to enforce a minimum margin (`x: 2`, `y: 5`) when determining the start position. This ensures the start position is within walkable space and respects the defined margins.