### PR TITLE
fix: fix awards rendering issue

### DIFF
--- a/frontend/src/assets/assets.ts
+++ b/frontend/src/assets/assets.ts
@@ -105,7 +105,7 @@ export const FruitAssets = {
     frameHeight: 32,
     starFrame: 0,
     endFrame: 17,
-    scale: 2000,
+    scale: 2,
   },
   CHERRIES: {
     assetKey: "CHERRIES",

--- a/frontend/src/common-ui/awards.ts
+++ b/frontend/src/common-ui/awards.ts
@@ -1,5 +1,4 @@
 import { BoxColors } from "assets/colors";
-import { AnimalAssets, FruitAssets } from "assets/assets";
 import { MAP_WIDTH, TILE_SIZE } from "config";
 import { AnimationManager, FRAME_RATE } from "managers/animation-manager";
 import type { AssetConfig } from "types/asset";
@@ -20,7 +19,6 @@ export type AwardConfig = {
   scene: Phaser.Scene;
   asset: AssetConfig;
   quantity: number;
-  scale?: number;
 };
 
 export class Awards {
@@ -55,13 +53,10 @@ export class Awards {
 
     this.scene = config.scene;
     this.asset = config.asset;
-    this.keyAnim = `AwardsKeyAnim_${this.asset.assetKey}`;
+    this.keyAnim = `AwardsKeyAnim_${config.asset.assetKey}`;
     this.positionX = AWARDS_CONFIG.POSITION_X;
     this.positionY = AWARDS_CONFIG.POSITION_Y;
-    this.scale =
-      (AnimalAssets as any)[this.asset.assetKey]?.scale ||
-      (FruitAssets as any)[this.asset.assetKey]?.scale ||
-      2;
+    this.scale = config.asset.scale || AWARDS_CONFIG.SCALE;
     this.padding = AWARDS_CONFIG.PADDING;
     AnimationManager.createAnimation(this.scene, {
       ...this.asset,

--- a/frontend/src/types/asset.d.ts
+++ b/frontend/src/types/asset.d.ts
@@ -1,6 +1,7 @@
 export type AssetConfig = {
   assetKey: string;
   animationKey?: string;
+  scale?: number;
   frameWidth?: number;
   frameHeight?: number;
   starFrame?: number;


### PR DESCRIPTION
This pull request refactors the scaling logic for assets in the awards system and simplifies the `Awards` class configuration. Key changes include removing hardcoded scaling logic and relying on the `AssetConfig` for scale values, as well as cleaning up unused imports.

### Refactoring asset scaling:

* [`frontend/src/assets/assets.ts`](diffhunk://#diff-26c33171d2c10da483879602141026da79adc0068bdce8ca617290b02ca6bae4L108-R108): Updated the `scale` value for the `BANANA` asset from `2000` to `2` to standardize scaling.
* [`frontend/src/common-ui/awards.ts`](diffhunk://#diff-e024cf6b80074b60791b6d3ffe481c7b934b4b5648e65a1fee652f2584708becL58-R59): Removed the fallback logic for scale in the `Awards` class, now relying on the `scale` property from `AssetConfig` or a default value from `AWARDS_CONFIG.SCALE`.

### Code cleanup:

* [`frontend/src/common-ui/awards.ts`](diffhunk://#diff-e024cf6b80074b60791b6d3ffe481c7b934b4b5648e65a1fee652f2584708becL23): Removed the optional `scale` property from the `AwardConfig` type, as it is now handled consistently through `AssetConfig`.
* [`frontend/src/common-ui/awards.ts`](diffhunk://#diff-e024cf6b80074b60791b6d3ffe481c7b934b4b5648e65a1fee652f2584708becL2): Removed unused import of `AnimalAssets` and `FruitAssets` to streamline dependencies.