### PR TITLE
feat: make dialog text uppercase

### DIFF
--- a/frontend/src/common-ui/dialog.ts
+++ b/frontend/src/common-ui/dialog.ts
@@ -36,7 +36,7 @@ export class Dialog extends BaseDialog {
     AnimationManager.animateText(
       this.scene,
       this.statementUI,
-      this.messagesToShow.shift() || "",
+      this.messagesToShow.shift()?.toUpperCase() || "",
       10,
       () => {
         this.textAnimationPlaying = false;


### PR DESCRIPTION
This pull request includes a minor update to the `Dialog` class in `frontend/src/common-ui/dialog.ts` to improve the display of messages during animations.

* [`frontend/src/common-ui/dialog.ts`](diffhunk://#diff-caaa4ef0ec4c2308b7fa622dc1e842e87ef8344238f1a056bad2c5251304d655L39-R39): Modified the `animateText` method to convert the next message in the `messagesToShow` queue to uppercase before displaying it.