### PR TITLE
fix: increase post-level scene delay and reduce loading bar delay

### DIFF
--- a/frontend/src/scenes/levels/base-level-scene.ts
+++ b/frontend/src/scenes/levels/base-level-scene.ts
@@ -385,11 +385,13 @@ export abstract class BaseLevelScene extends Scene {
 
     StorageManager.setLevelMetadaDataInRegistry(this.game, this.currentLevel);
 
-    this.cameras.main.fadeOut(2000, 0, 0, 0, () => {
-      setTimeout(() => {
+    this.cameras.main.once(
+      Phaser.Cameras.Scene2D.Events.FADE_OUT_COMPLETE,
+      () => {
         this.scene.start(SceneKeys.WIN_SCENE);
-      }, 1000);
-    });
+      },
+    );
+    this.cameras.main.fadeOut(6000, 0, 0, 0);
   }
 
   private setElementsVisibility(

--- a/frontend/src/scenes/preloader.ts
+++ b/frontend/src/scenes/preloader.ts
@@ -158,17 +158,16 @@ export default class Preloader extends Scene {
   }
 
   create(): void {
+    this.createPlayerAnimations();
     // delay to see the bar
-    this.time.delayedCall(2000, () => {
-      this.createPlayerAnimations();
-
+    this.time.delayedCall(1000, () => {
       this.scene.start(
         DEBUG_MODE_ACTIVE ? FIRST_SCENE_TO_PLAY : SceneKeys.MAIN_MENU,
       );
     });
   }
 
-  update() {
+  update(): void {
     const { centerX, centerY } = this.cameras.main;
 
     this.currentProgress = Phaser.Math.Linear(
@@ -189,7 +188,7 @@ export default class Preloader extends Scene {
     this.percentText.setText(`${Math.floor(this.currentProgress * 100)}%`);
   }
 
-  private createPlayerAnimations() {
+  private createPlayerAnimations(): void {
     AnimationManager.createPlayerAnimation(
       this,
       PlayerAnimationKeys.PLAYER_UP,
@@ -216,7 +215,7 @@ export default class Preloader extends Scene {
     );
   }
 
-  private loadFruits() {
+  private loadFruits(): void {
     const fruits = Object.keys(FruitAssets);
     fruits.forEach((fruit) =>
       this.loadContent("/items/fruits", fruit as keyof typeof FruitAssets),


### PR DESCRIPTION
This pull request makes adjustments to scene transitions and code consistency in the `BaseLevelScene` and `Preloader` classes. The most important changes include modifying the fade-out transition in `BaseLevelScene`, reducing delays in the `Preloader` scene, and improving code clarity with explicit return types for private methods.

### Scene Transition Improvements:
* [`frontend/src/scenes/levels/base-level-scene.ts`](diffhunk://#diff-a8dabbd1c0850c207bc95b6ea3a89c2070152ac25e2c83ed8b8d9864625c9e8cL388-R394): Updated the fade-out transition in `BaseLevelScene` to use a `Phaser` event listener for `FADE_OUT_COMPLETE` and extended the fade-out duration from 2000ms to 6000ms. This ensures cleaner scene transition handling.

* [`frontend/src/scenes/preloader.ts`](diffhunk://#diff-1f0eaf97b83a31b59a98836daf4caa6878e135d38fd6106e6e99e4a2f93feac7L161-R170): Reduced the delay before transitioning from the `Preloader` scene from 2000ms to 1000ms, making the scene load faster while still allowing the progress bar to be visible.

### Code Consistency Improvements:
* [`frontend/src/scenes/preloader.ts`](diffhunk://#diff-1f0eaf97b83a31b59a98836daf4caa6878e135d38fd6106e6e99e4a2f93feac7L192-R191): Added explicit `void` return types to private methods such as `createPlayerAnimations` and `loadFruits`, improving code clarity and consistency. [[1]](diffhunk://#diff-1f0eaf97b83a31b59a98836daf4caa6878e135d38fd6106e6e99e4a2f93feac7L192-R191) [[2]](diffhunk://#diff-1f0eaf97b83a31b59a98836daf4caa6878e135d38fd6106e6e99e4a2f93feac7L219-R218)