### PR TITLE
refactor: rename Awards to RequestedItems

### DIFF
--- a/frontend/src/common-ui/requested-items.ts
+++ b/frontend/src/common-ui/requested-items.ts
@@ -15,13 +15,13 @@ const AWARDS_CONFIG = {
   FADE_OUT_DURATION: 200,
 };
 
-export type AwardConfig = {
+export type RequestedItemConfig = {
   scene: Phaser.Scene;
   asset: AssetConfig;
   quantity: number;
 };
 
-export class Awards {
+export class RequestedItems {
   private scene: Phaser.Scene;
 
   private asset: AssetConfig;
@@ -46,14 +46,14 @@ export class Awards {
     return this.sprites.length;
   }
 
-  constructor(config: AwardConfig) {
+  constructor(config: RequestedItemConfig) {
     if (!config.scene || !config.asset) {
-      throw new Error("Invalid Awards configuration");
+      throw new Error("Invalid Requested Items configuration");
     }
 
     this.scene = config.scene;
     this.asset = config.asset;
-    this.keyAnim = `AwardsKeyAnim_${config.asset.assetKey}`;
+    this.keyAnim = `RequestedItemsKeyAnim_${config.asset.assetKey}`;
     this.positionX = AWARDS_CONFIG.POSITION_X;
     this.positionY = AWARDS_CONFIG.POSITION_Y;
     this.scale = config.asset.scale || AWARDS_CONFIG.SCALE;

--- a/frontend/src/scenes/levels/base-level-scene.ts
+++ b/frontend/src/scenes/levels/base-level-scene.ts
@@ -20,7 +20,7 @@ import {
   TILE_SIZE,
 } from "config";
 import { MapGenerator } from "common/map/map-generator";
-import { Awards } from "common-ui/awards";
+import { RequestedItems } from "common-ui/requested-items";
 import { HealthBar } from "common-ui/health-bar";
 import { DIRECTION } from "common/player-keys";
 import { TileKeys, CharacterAssets } from "assets/assets";
@@ -40,7 +40,7 @@ export abstract class BaseLevelScene extends Scene {
 
   protected healthBar!: HealthBar;
 
-  protected awards!: Awards;
+  protected awards!: RequestedItems;
 
   protected heldItem?: Phaser.GameObjects.Sprite;
 
@@ -219,7 +219,7 @@ export abstract class BaseLevelScene extends Scene {
       this.awards.destroy();
     }
 
-    this.awards = new Awards({
+    this.awards = new RequestedItems({
       scene: this,
       asset,
       quantity,


### PR DESCRIPTION
This pull request refactors the `Awards` class and its related components to improve naming consistency and better reflect its purpose. The class has been renamed to `RequestedItems`, and corresponding changes have been made to type definitions, imports, and usage throughout the codebase.

### Refactoring of `Awards` to `RequestedItems`:

* Renamed `Awards` class to `RequestedItems` and updated the associated type from `AwardConfig` to `RequestedItemConfig`. Updated error messages and animation key prefixes to align with the new naming. (`frontend/src/common-ui/requested-items.ts`, renamed from `frontend/src/common-ui/awards.ts`) [[1]](diffhunk://#diff-9bdbfaa657af431ccf8ad92fac19ac04521094a441bce3b00e99e1afc6402dbaL18-R24) [[2]](diffhunk://#diff-9bdbfaa657af431ccf8ad92fac19ac04521094a441bce3b00e99e1afc6402dbaL49-R56)

### Updates to imports and usage:

* Updated imports in `frontend/src/scenes/levels/base-level-scene.ts` to reflect the renaming of `Awards` to `RequestedItems`.
* Replaced `Awards` with `RequestedItems` in the `BaseLevelScene` class, including property definitions and instantiation logic. [[1]](diffhunk://#diff-a8dabbd1c0850c207bc95b6ea3a89c2070152ac25e2c83ed8b8d9864625c9e8cL43-R43) [[2]](diffhunk://#diff-a8dabbd1c0850c207bc95b6ea3a89c2070152ac25e2c83ed8b8d9864625c9e8cL222-R222)