### PR TITLE
fix: prevent dropping items outside the map

### DIFF
--- a/frontend/src/scenes/levels/base-level-scene.ts
+++ b/frontend/src/scenes/levels/base-level-scene.ts
@@ -277,6 +277,11 @@ export abstract class BaseLevelScene extends Scene {
         dropY = this.player.y;
     }
 
+    const worldWidth = this.physics.world.bounds.width;
+    const worldHeight = this.physics.world.bounds.height;
+    dropX = Phaser.Math.Clamp(dropX, 0, worldWidth - TILE_SIZE);
+    dropY = Phaser.Math.Clamp(dropY, 0, worldHeight - TILE_SIZE);
+
     const canDrop =
       this.physics
         .overlapRect(dropX, dropY, TILE_SIZE, TILE_SIZE, true, true)


### PR DESCRIPTION
This pull request includes a small but important change to the `BaseLevelScene` class in `frontend/src/scenes/levels/base-level-scene.ts`. The change ensures that item drop coordinates are clamped within the bounds of the game world, preventing items from being dropped outside the playable area.

* [`frontend/src/scenes/levels/base-level-scene.ts`](diffhunk://#diff-a8dabbd1c0850c207bc95b6ea3a89c2070152ac25e2c83ed8b8d9864625c9e8cR280-R284): Added `worldWidth` and `worldHeight` variables to retrieve the dimensions of the game world, and used `Phaser.Math.Clamp` to restrict `dropX` and `dropY` values to valid positions within the world bounds.