### PR TITLE
fix: prevent dropping items while talking to an NPC

### DIFF
--- a/frontend/src/scenes/levels/base-level-scene.ts
+++ b/frontend/src/scenes/levels/base-level-scene.ts
@@ -105,11 +105,19 @@ export abstract class BaseLevelScene extends Scene {
     if (!this.controls) return;
 
     if (this.controls.wasSpaceKeyPressed()) {
-      this.handlePlayerInteraction();
+      if (this.dialog?.isVisible) {
+        this.dialog.showNextMessage();
+        return;
+      }
+
+      this.tryToInteractWithNearNPC();
+
+      if (this.heldItem && !this.dialog?.isVisible) {
+        this.tryDropHeldItem();
+      }
+
       return;
     }
-
-    if (this.dialog?.isVisible) return;
 
     this.player.move(this.controls.getDirectionKeyPressed());
 
@@ -237,19 +245,6 @@ export abstract class BaseLevelScene extends Scene {
     }
   }
 
-  private handlePlayerInteraction(): void {
-    if (this.dialog?.isVisible) {
-      this.dialog.showNextMessage();
-      return;
-    }
-
-    this.interactWithNearNPC();
-
-    if (this.heldItem) {
-      this.tryDropHeldItem();
-    }
-  }
-
   private tryDropHeldItem() {
     const playerDirection = this.player.direction;
     let dropX = 0;
@@ -304,7 +299,7 @@ export abstract class BaseLevelScene extends Scene {
     }
   }
 
-  private interactWithNearNPC(): void {
+  private tryToInteractWithNearNPC(): void {
     this.map.assetGroups
       .get(CharacterAssets.NPC)!
       .getChildren()


### PR DESCRIPTION
This pull request refactors the `BaseLevelScene` class in `frontend/src/scenes/levels/base-level-scene.ts` to improve the clarity and modularity of player interaction logic. The main changes include removing the `handlePlayerInteraction` method, reorganizing the interaction flow, and renaming a method for better readability.

### Refactoring of player interaction logic:

* The `handlePlayerInteraction` method was removed, and its logic was directly integrated into the main control flow, simplifying the structure and improving readability. [[1]](diffhunk://#diff-a8dabbd1c0850c207bc95b6ea3a89c2070152ac25e2c83ed8b8d9864625c9e8cL108-R120) [[2]](diffhunk://#diff-a8dabbd1c0850c207bc95b6ea3a89c2070152ac25e2c83ed8b8d9864625c9e8cL240-L252)

* The interaction logic now checks if a dialog is visible and either progresses the dialog or attempts interactions with nearby NPCs and held items, ensuring a clearer sequence of actions.

### Method renaming for clarity:

* The `interactWithNearNPC` method was renamed to `tryToInteractWithNearNPC` to better reflect its purpose and behavior.