### PR TITLE
fix: adjust depth values to prevent object overlap

### DIFF
--- a/frontend/src/common-ui/base-dialog.ts
+++ b/frontend/src/common-ui/base-dialog.ts
@@ -2,7 +2,7 @@ import Phaser from "phaser";
 import type { DialogData } from "types/dialog-data";
 import { BoxColors } from "assets/colors";
 import { FontSize, PRIMARY_FONT_FAMILY } from "assets/fonts";
-import { DEPTH_100 } from "config";
+import { DEPTH_1 } from "config";
 
 export type DialogConfig = {
   scene: Phaser.Scene;
@@ -89,7 +89,7 @@ export abstract class BaseDialog {
 
     this.container = this.scene.add
       .container(positionX, positionY, children)
-      .setDepth(DEPTH_100);
+      .setDepth(DEPTH_1);
   }
 
   private createPanel(): Phaser.GameObjects.Rectangle {

--- a/frontend/src/common-ui/base-dialog.ts
+++ b/frontend/src/common-ui/base-dialog.ts
@@ -2,6 +2,7 @@ import Phaser from "phaser";
 import type { DialogData } from "types/dialog-data";
 import { BoxColors } from "assets/colors";
 import { FontSize, PRIMARY_FONT_FAMILY } from "assets/fonts";
+import { DEPTH_100 } from "config";
 
 export type DialogConfig = {
   scene: Phaser.Scene;
@@ -86,7 +87,9 @@ export abstract class BaseDialog {
     const positionY =
       this.scene.cameras.main.height - this.height - this.padding / 4;
 
-    this.container = this.scene.add.container(positionX, positionY, children);
+    this.container = this.scene.add
+      .container(positionX, positionY, children)
+      .setDepth(DEPTH_100);
   }
 
   private createPanel(): Phaser.GameObjects.Rectangle {

--- a/frontend/src/common-ui/health-bar.ts
+++ b/frontend/src/common-ui/health-bar.ts
@@ -1,4 +1,4 @@
-import { DEPTH_100, GAME_DIMENSIONS, TILE_SIZE } from "config";
+import { DEPTH_1, GAME_DIMENSIONS, TILE_SIZE } from "config";
 import { UIComponentKeys } from "assets/assets";
 
 const HEALTH_BAR_CONFIG = {
@@ -57,7 +57,7 @@ export class HealthBar {
 
     this.scene.add
       .container(x, y, [this.background, this.fillBarLeft, this.fillBarRight])
-      .setDepth(DEPTH_100);
+      .setDepth(DEPTH_1);
   }
 
   private createBackgroundBar(): void {

--- a/frontend/src/common-ui/health-bar.ts
+++ b/frontend/src/common-ui/health-bar.ts
@@ -1,4 +1,4 @@
-import { GAME_DIMENSIONS, TILE_SIZE } from "config";
+import { DEPTH_100, GAME_DIMENSIONS, TILE_SIZE } from "config";
 import { UIComponentKeys } from "assets/assets";
 
 const HEALTH_BAR_CONFIG = {
@@ -55,11 +55,9 @@ export class HealthBar {
     this.createBackgroundBar();
     this.createFillBar();
 
-    this.scene.add.container(x, y, [
-      this.background,
-      this.fillBarLeft,
-      this.fillBarRight,
-    ]);
+    this.scene.add
+      .container(x, y, [this.background, this.fillBarLeft, this.fillBarRight])
+      .setDepth(DEPTH_100);
   }
 
   private createBackgroundBar(): void {

--- a/frontend/src/common-ui/requested-items.ts
+++ b/frontend/src/common-ui/requested-items.ts
@@ -1,5 +1,5 @@
 import { BoxColors } from "assets/colors";
-import { MAP_WIDTH, TILE_SIZE } from "config";
+import { DEPTH_100, MAP_WIDTH, TILE_SIZE } from "config";
 import { AnimationManager, FRAME_RATE } from "managers/animation-manager";
 import type { AssetConfig } from "types/asset";
 
@@ -105,11 +105,13 @@ export class RequestedItems {
   private initializeUI(quantity: number): void {
     this.createBackground();
 
-    this.container = this.scene.add.container(
-      this.positionX - this.background.displayWidth,
-      this.positionY,
-      [this.background],
-    );
+    this.container = this.scene.add
+      .container(
+        this.positionX - this.background.displayWidth,
+        this.positionY,
+        [this.background],
+      )
+      .setDepth(DEPTH_100);
 
     this.addAwards(quantity);
   }

--- a/frontend/src/common-ui/requested-items.ts
+++ b/frontend/src/common-ui/requested-items.ts
@@ -1,5 +1,5 @@
 import { BoxColors } from "assets/colors";
-import { DEPTH_100, MAP_WIDTH, TILE_SIZE } from "config";
+import { DEPTH_1, MAP_WIDTH, TILE_SIZE } from "config";
 import { AnimationManager, FRAME_RATE } from "managers/animation-manager";
 import type { AssetConfig } from "types/asset";
 
@@ -111,7 +111,7 @@ export class RequestedItems {
         this.positionY,
         [this.background],
       )
-      .setDepth(DEPTH_100);
+      .setDepth(DEPTH_1);
 
     this.addAwards(quantity);
   }

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -17,4 +17,4 @@ export const MIN_PARTITION_SIZE = 5; // MIN_PARTITION_SIZE < MIN(MAP_WIDTH, MAP_
 export const MIN_ROOM_SIZE = 5; // MIN_ROOM_SIZE < MIN(MAP_WIDTH, MAP_HEIGHT) / 2
 
 // DEPTH VALUES
-export const DEPTH_100 = 100;
+export const DEPTH_1 = 100;

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -15,3 +15,6 @@ export const MAP_WIDTH = 24;
 export const MAP_HEIGHT = 24;
 export const MIN_PARTITION_SIZE = 5; // MIN_PARTITION_SIZE < MIN(MAP_WIDTH, MAP_HEIGHT) / 2
 export const MIN_ROOM_SIZE = 5; // MIN_ROOM_SIZE < MIN(MAP_WIDTH, MAP_HEIGHT) / 2
+
+// DEPTH VALUES
+export const DEPTH_100 = 100;


### PR DESCRIPTION
This pull request introduces a new constant, `DEPTH_100`, to standardize the depth value for UI components and updates several UI classes to use this constant for setting depth. The changes improve consistency and maintainability in managing rendering order for UI elements.

### Introduction of `DEPTH_100` Constant:
* Added `DEPTH_100` constant in `frontend/src/config.ts` to represent a depth value of 100 for UI components.

### Updates to UI Components:
* **`BaseDialog` (`frontend/src/common-ui/base-dialog.ts`)**:
  - Imported `DEPTH_100` and updated the container initialization to use `.setDepth(DEPTH_100)` for consistent depth management. [[1]](diffhunk://#diff-654a90a17c569b8d91787f38324c52ee69bd1a43d1a0e0d30ccc234201e806f7R5) [[2]](diffhunk://#diff-654a90a17c569b8d91787f38324c52ee69bd1a43d1a0e0d30ccc234201e806f7L89-R92)
* **`HealthBar` (`frontend/src/common-ui/health-bar.ts`)**:
  - Imported `DEPTH_100` and updated the container initialization to include `.setDepth(DEPTH_100)`. [[1]](diffhunk://#diff-b1e775f19a33c126cbdbbfe9bb2a97d4e3c2922595ffad64255572d8a6328fcaL1-R1) [[2]](diffhunk://#diff-b1e775f19a33c126cbdbbfe9bb2a97d4e3c2922595ffad64255572d8a6328fcaL58-R60)
* **`RequestedItems` (`frontend/src/common-ui/requested-items.ts`)**:
  - Imported `DEPTH_100` and updated the UI container to use `.setDepth(DEPTH_100)`. [[1]](diffhunk://#diff-9bdbfaa657af431ccf8ad92fac19ac04521094a441bce3b00e99e1afc6402dbaL2-R2) [[2]](diffhunk://#diff-9bdbfaa657af431ccf8ad92fac19ac04521094a441bce3b00e99e1afc6402dbaL108-R114)