### PR TITLE
improvement: change level only after last dialog is closed

### DIFF
--- a/frontend/src/common-ui/base-dialog.ts
+++ b/frontend/src/common-ui/base-dialog.ts
@@ -2,11 +2,11 @@ import Phaser from "phaser";
 import type { DialogData } from "types/dialog-data";
 import { BoxColors } from "assets/colors";
 import { FontSize, PRIMARY_FONT_FAMILY } from "assets/fonts";
+import { loadDialogData } from "managers/dialog-data-manager";
 import { DEPTH_1 } from "config";
 
 export type DialogConfig = {
   scene: Phaser.Scene;
-  data: DialogData[];
   height?: number;
   width?: number;
   padding?: number;
@@ -44,21 +44,21 @@ export abstract class BaseDialog {
     this.container.visible = value;
   }
 
+  get areAllDialogsCompleted(): boolean {
+    return this.data.every((dialog) => dialog.completed);
+  }
+
   abstract show(npcId?: string): void;
   abstract hide(): void;
   abstract setMessageComplete(npcId?: string): void;
 
   constructor(config: DialogConfig) {
     this.scene = config.scene;
-    this.data = config.data;
+    this.data = loadDialogData(config.scene);
     this.height = config.height || 200;
     this.padding = config.padding || 60;
     this.width =
       config.width || this.scene.cameras.main.width - this.padding * 2;
-  }
-
-  areAllDialogsCompleted(): boolean {
-    return this.data.every((dialog) => dialog.completed);
   }
 
   protected initializeUI(): void {

--- a/frontend/src/common-ui/dialog-with-options.ts
+++ b/frontend/src/common-ui/dialog-with-options.ts
@@ -10,6 +10,7 @@ import {
 import type { DialogData } from "types/dialog-data";
 import { AnimationManager } from "managers/animation-manager";
 import { UIComponentKeys } from "assets/assets";
+import { loadDialogData } from "managers/dialog-data-manager";
 import type { DialogConfig } from "./base-dialog";
 
 const MENU_CURSOR_POS = {
@@ -80,7 +81,7 @@ export class DialogWithOptions {
 
   constructor(config: DialogWithOptionsConfig) {
     this.scene = config.scene;
-    this.data = config.data;
+    this.data = loadDialogData(config.scene);
     this.#height = config.height || 200;
     this.#padding = config.padding || 60;
     this.#width =


### PR DESCRIPTION
This pull request introduces several changes to improve the handling of dialog data and level metadata in the game. The key updates include centralizing dialog data loading, renaming and restructuring level metadata properties for clarity, and adding new functionality to manage scene transitions. Below is a breakdown of the most important changes grouped by theme:

### Dialog Data Management
* Replaced the `data` property in `BaseDialog` and `DialogWithOptions` with a call to `loadDialogData` to centralize dialog data loading. This eliminates the need to pass dialog data explicitly during initialization. (`frontend/src/common-ui/base-dialog.ts`, `frontend/src/common-ui/dialog-with-options.ts`) [[1]](diffhunk://#diff-654a90a17c569b8d91787f38324c52ee69bd1a43d1a0e0d30ccc234201e806f7R5-L9) [[2]](diffhunk://#diff-654a90a17c569b8d91787f38324c52ee69bd1a43d1a0e0d30ccc234201e806f7R47-L63) [[3]](diffhunk://#diff-50c6b9c2dbe1fe5205fb64c65cd29e425f6c9e9901183753f014e9e27f6f5ee3R13) [[4]](diffhunk://#diff-50c6b9c2dbe1fe5205fb64c65cd29e425f6c9e9901183753f014e9e27f6f5ee3L83-R84)
* Removed the redundant `areAllDialogsCompleted` method and replaced it with a getter for improved readability and consistency. (`frontend/src/common-ui/base-dialog.ts`)

### Level Metadata Refactoring
* Renamed `levelsMetadata` to `allLevelsMetadata` and `currentLevel` to `levelMetadata` in `BaseLevelScene` to improve clarity and align with their usage. (`frontend/src/scenes/levels/base-level-scene.ts`) [[1]](diffhunk://#diff-a8dabbd1c0850c207bc95b6ea3a89c2070152ac25e2c83ed8b8d9864625c9e8cL49-R51) [[2]](diffhunk://#diff-a8dabbd1c0850c207bc95b6ea3a89c2070152ac25e2c83ed8b8d9864625c9e8cL65-L94)
* Updated `StorageManager` calls to use the renamed `levelMetadata` property for saving and retrieving level data. (`frontend/src/scenes/levels/base-level-scene.ts`)

### Scene Transition Enhancements
* Added a `closingScene` method to handle the transition when all dialogs are completed, including a fade-out effect and scene switch to the win screen. (`frontend/src/scenes/levels/base-level-scene.ts`) [[1]](diffhunk://#diff-a8dabbd1c0850c207bc95b6ea3a89c2070152ac25e2c83ed8b8d9864625c9e8cR113-R124) [[2]](diffhunk://#diff-a8dabbd1c0850c207bc95b6ea3a89c2070152ac25e2c83ed8b8d9864625c9e8cL378-L394)
* Introduced a `closingSceneStarting` flag to prevent multiple transitions from being triggered simultaneously. (`frontend/src/scenes/levels/base-level-scene.ts`) [[1]](diffhunk://#diff-a8dabbd1c0850c207bc95b6ea3a89c2070152ac25e2c83ed8b8d9864625c9e8cL49-R51) [[2]](diffhunk://#diff-a8dabbd1c0850c207bc95b6ea3a89c2070152ac25e2c83ed8b8d9864625c9e8cR113-R124)

### Miscellaneous Changes
* Removed unused imports and cleaned up code for better maintainability. (`frontend/src/scenes/levels/base-level-scene.ts`) [[1]](diffhunk://#diff-a8dabbd1c0850c207bc95b6ea3a89c2070152ac25e2c83ed8b8d9864625c9e8cL2) [[2]](diffhunk://#diff-a8dabbd1c0850c207bc95b6ea3a89c2070152ac25e2c83ed8b8d9864625c9e8cL14)

These changes collectively improve the maintainability, readability, and functionality of the dialog and level systems in the game.