### PR TITLE
fix: prevent space key from switching scenes on win and game-over screens

### DIFF
--- a/frontend/src/scenes/game-over.ts
+++ b/frontend/src/scenes/game-over.ts
@@ -1,29 +1,36 @@
-import Phaser from "phaser";
+import { Scene } from "phaser";
 import { ItemAssets, UIComponentKeys } from "assets/assets";
 import { AnimationManager } from "managers/animation-manager";
 import { FontSize, PRIMARY_FONT_FAMILY } from "assets/fonts";
 import { StorageManager } from "managers/storage-manager";
+import { Controls } from "common/controls";
 import { SceneKeys } from "./scene-keys";
 
-export default class GameOver extends Phaser.Scene {
+export default class GameOver extends Scene {
+  private controls!: Controls;
+
   constructor() {
     super(SceneKeys.GAME_OVER);
   }
 
   create(): void {
     this.initializeUI();
+    this.controls = new Controls(this);
+  }
 
-    this.input.keyboard?.once("keydown-SPACE", () => {
+  update(): void {
+    if (this.controls.wasSpaceKeyPressed()) {
       const currentLevel = StorageManager.getLevelMetadataFromRegistry(
         this.game,
       );
+
       if (currentLevel?.key) {
         this.scene.start(currentLevel.key);
       }
-    });
+    }
   }
 
-  private initializeUI() {
+  private initializeUI(): void {
     this.setupBackground();
     this.createGameOverImage();
     this.createRestartText();

--- a/frontend/src/scenes/win-scene.ts
+++ b/frontend/src/scenes/win-scene.ts
@@ -1,19 +1,25 @@
-import Phaser from "phaser";
+import { Scene } from "phaser";
 import { UIComponentKeys, BackgroundKeys } from "assets/assets";
 import { PRIMARY_FONT_FAMILY, FontSize } from "assets/fonts";
+import { Controls } from "common/controls";
 import { SceneKeys } from "./scene-keys";
 
-export default class WinScene extends Phaser.Scene {
+export default class WinScene extends Scene {
+  private controls!: Controls;
+
   constructor() {
     super(SceneKeys.WIN_SCENE);
   }
 
   create(): void {
     this.initializeUI();
+    this.controls = new Controls(this);
+  }
 
-    this.input.keyboard?.once("keydown-SPACE", () => {
+  update(): void {
+    if (this.controls.wasSpaceKeyPressed()) {
       this.scene.start(SceneKeys.LEVELS_MENU);
-    });
+    }
   }
 
   private initializeUI(): void {


### PR DESCRIPTION
This pull request refactors the `GameOver` and `WinScene` classes to enhance code maintainability and introduce a reusable input handling mechanism. The most important changes include replacing direct `Phaser` imports with specific `Scene` imports, integrating a new `Controls` class for input handling, and updating the `update` methods to use the new input abstraction.

### Refactoring for maintainability:

* Replaced the default `Phaser.Scene` import with a specific `Scene` import in both `GameOver` (`frontend/src/scenes/game-over.ts`) and `WinScene` (`frontend/src/scenes/win-scene.ts`) classes for clearer dependency management. [[1]](diffhunk://#diff-ab470d8d57efcc478366e7b74b2b965c46683ac226789e1b8d2b6d71c0e8e598L1-R33) [[2]](diffhunk://#diff-28013a85c45c35662767ea4efac8c049ae259c3dd935e4a2353ea9717713254aL1-R22)

### Input handling improvements:

* Introduced the `Controls` class in both `GameOver` and `WinScene` to abstract keyboard input handling, replacing the direct use of `this.input.keyboard`. This improves code reusability and encapsulation. [[1]](diffhunk://#diff-ab470d8d57efcc478366e7b74b2b965c46683ac226789e1b8d2b6d71c0e8e598L1-R33) [[2]](diffhunk://#diff-28013a85c45c35662767ea4efac8c049ae259c3dd935e4a2353ea9717713254aL1-R22)
* Updated the `update` methods in `GameOver` and `WinScene` to use the `Controls.wasSpaceKeyPressed()` method for detecting space key presses, ensuring consistent input handling across scenes. [[1]](diffhunk://#diff-ab470d8d57efcc478366e7b74b2b965c46683ac226789e1b8d2b6d71c0e8e598L1-R33) [[2]](diffhunk://#diff-28013a85c45c35662767ea4efac8c049ae259c3dd935e4a2353ea9717713254aL1-R22)