### PR TITLE
fix: allow unlocking multiple levels at once and requiring multiple predecessors to unlock a level; add hack for unlocking levels

### DIFF
--- a/frontend/src/scenes/levels/levels-config.ts
+++ b/frontend/src/scenes/levels/levels-config.ts
@@ -7,31 +7,37 @@ export const levelsConfig: LevelMetadata[] = [
     position: { x: 260, y: 420 },
     enable: true,
     nextLevel: [SceneKeys.LEVEL_2],
+    previousLevel: [],
   },
   {
     key: SceneKeys.LEVEL_2,
     position: { x: 450, y: 620 },
     nextLevel: [SceneKeys.LEVEL_3],
+    previousLevel: [SceneKeys.LEVEL_1],
   },
   {
     key: SceneKeys.LEVEL_3,
     position: { x: 820, y: 500 },
-    nextLevel: [SceneKeys.LEVEL_4],
+    nextLevel: [SceneKeys.LEVEL_4, SceneKeys.LEVEL_5],
+    previousLevel: [SceneKeys.LEVEL_2],
   },
   {
     key: SceneKeys.LEVEL_4,
     position: { x: 690, y: 260 },
     nextLevel: [SceneKeys.LEVEL_5],
+    previousLevel: [SceneKeys.LEVEL_3],
   },
   {
     key: SceneKeys.LEVEL_5,
     position: { x: 1370, y: 500 },
     nextLevel: [SceneKeys.LEVEL_6],
+    previousLevel: [SceneKeys.LEVEL_3],
   },
   {
     key: SceneKeys.LEVEL_6,
     position: { x: 1510, y: 210 },
     nextLevel: [SceneKeys.WIN_SCENE],
+    previousLevel: [SceneKeys.LEVEL_5],
   },
   /*
   {

--- a/frontend/src/types/level.d.ts
+++ b/frontend/src/types/level.d.ts
@@ -11,6 +11,7 @@ export type LevelMetadata = {
   completed?: boolean;
   active?: boolean;
   nextLevel?: string[];
+  previousLevel?: string[];
 };
 
 export type LevelConfig = MinimalMapConfiguration & {


### PR DESCRIPTION
This pull request introduces several enhancements to the `LevelsMenu` scene in the game, focusing on improving level unlocking logic, adding keyboard shortcuts for level activation, and refining the tooltip text. Additionally, it updates the level configuration to include predecessor information, enabling more robust dependency checks.

### Enhancements to level unlocking logic:
* Introduced a `levelKeyMap` in `LevelsMenu` for efficient lookups of level metadata by key, replacing repeated `find` calls with `Map` operations. [[1]](diffhunk://#diff-80f5891941c7c7c5b61360616781cef1fcbb244aaf9752e654eb5297da594e7dR14-R15) [[2]](diffhunk://#diff-80f5891941c7c7c5b61360616781cef1fcbb244aaf9752e654eb5297da594e7dR27-R42) [[3]](diffhunk://#diff-80f5891941c7c7c5b61360616781cef1fcbb244aaf9752e654eb5297da594e7dL141-R209)
* Added a new method `areAllPredecessorsCompleted` to validate if all predecessor levels are completed before unlocking a level.

### Keyboard shortcuts for level activation:
* Implemented the `setupKeyboardShortcuts` method to allow players to unlock levels using number keys (1–9). This feature updates the level metadata and restarts the scene to reflect changes.

### Tooltip improvements:
* Updated the tooltip text from Spanish ("Completa el nivel anterior para desbloquear") to English ("Complete the previous level to unlock") for consistency. [[1]](diffhunk://#diff-80f5891941c7c7c5b61360616781cef1fcbb244aaf9752e654eb5297da594e7dL49-R52) [[2]](diffhunk://#diff-80f5891941c7c7c5b61360616781cef1fcbb244aaf9752e654eb5297da594e7dL97-R97)

### Updates to level configuration:
* Added a `previousLevel` field to each level in `levelsConfig`, enabling the game to track predecessor levels for dependency checks.