### PR TITLE
fix: stop player animation when dialog opens

### DIFF
--- a/frontend/src/scenes/levels/base-level-scene.ts
+++ b/frontend/src/scenes/levels/base-level-scene.ts
@@ -105,7 +105,7 @@ export abstract class BaseLevelScene extends Scene {
 
       if (this.heldItem && !this.dialog?.isVisible) {
         this.tryDropHeldItem();
-      }
+      } 
 
       return;
     }
@@ -321,6 +321,7 @@ export abstract class BaseLevelScene extends Scene {
   private handleInteractionNPC(npc: Phaser.GameObjects.Sprite): void {
     if (!this.dialog?.isDialogActive()) {
       this.startDialogWithNPC(npc);
+      this.player.stop();
       return;
     }
 


### PR DESCRIPTION
This pull request introduces a minor improvement to the `BaseLevelScene` class by ensuring the player stops moving when initiating a dialog with an NPC.

* [`frontend/src/scenes/levels/base-level-scene.ts`](diffhunk://#diff-a8dabbd1c0850c207bc95b6ea3a89c2070152ac25e2c83ed8b8d9864625c9e8cR324): Added a call to `this.player.stop()` in the `handleInteractionNPC` method to halt player movement when starting a dialog with an NPC.