### PR TITLE
fix: fixed item dropping

### DIFF
--- a/frontend/src/scenes/levels/base-level-scene.ts
+++ b/frontend/src/scenes/levels/base-level-scene.ts
@@ -21,7 +21,7 @@ import { MapGenerator } from "common/map/map-generator";
 import { RequestedItems } from "common-ui/requested-items";
 import { HealthBar } from "common-ui/health-bar";
 import { DIRECTION } from "common/player-keys";
-import { TileKeys, CharacterAssets } from "assets/assets";
+import { CharacterAssets } from "assets/assets";
 import type { LevelMetadata } from "types/level";
 import { StorageManager } from "managers/storage-manager";
 import type { AssetConfig } from "types/asset";
@@ -105,7 +105,7 @@ export abstract class BaseLevelScene extends Scene {
 
       if (this.heldItem && !this.dialog?.isVisible) {
         this.tryDropHeldItem();
-      } 
+      }
 
       return;
     }
@@ -246,45 +246,48 @@ export abstract class BaseLevelScene extends Scene {
   }
 
   private tryDropHeldItem() {
-    const playerDirection = this.player.direction;
+    const dropAreaSize = TILE_SIZE / 6;
+    const dropOffset = TILE_SIZE * 0.65;
+
     let dropX = 0;
     let dropY = 0;
-    switch (playerDirection) {
+    switch (this.player.direction) {
       case DIRECTION.UP:
         dropX = this.player.x;
-        dropY = this.player.y - TILE_SIZE;
+        dropY = this.player.y - dropOffset;
         break;
       case DIRECTION.DOWN:
         dropX = this.player.x;
-        dropY = this.player.y + TILE_SIZE;
+        dropY = this.player.y + dropOffset;
         break;
       case DIRECTION.LEFT:
-        dropX = this.player.x - TILE_SIZE;
+        dropX = this.player.x - dropOffset;
         dropY = this.player.y;
         break;
       case DIRECTION.RIGHT:
-        dropX = this.player.x + TILE_SIZE;
+        dropX = this.player.x + dropOffset;
         dropY = this.player.y;
         break;
       default:
-        console.error(`Unexpected player direction: ${playerDirection}`);
+        console.error(`Unexpected player direction: ${this.player.direction}`);
         dropX = this.player.x;
         dropY = this.player.y;
     }
 
     const worldWidth = this.physics.world.bounds.width;
     const worldHeight = this.physics.world.bounds.height;
-    dropX = Phaser.Math.Clamp(dropX, 0, worldWidth - TILE_SIZE);
-    dropY = Phaser.Math.Clamp(dropY, 0, worldHeight - TILE_SIZE);
+    dropX = Phaser.Math.Clamp(dropX, 0, worldWidth - dropAreaSize);
+    dropY = Phaser.Math.Clamp(dropY, 0, worldHeight - dropAreaSize);
 
     const canDrop =
       this.physics
-        .overlapRect(dropX, dropY, TILE_SIZE, TILE_SIZE, true, true)
-        .filter(
-          (ol) =>
-            ol.gameObject instanceof GameObjects.Image &&
-            (ol.gameObject.texture.key !== TileKeys.TREE || // this should not depend on the tree tile
-              ol.gameObject.texture.key !== CharacterAssets.NPC),
+        .overlapRect(dropX, dropY, dropAreaSize, dropAreaSize, true, true)
+        .filter((ol) =>
+          this.obstacles.some(
+            (obstacle) =>
+              obstacle.assetKey ===
+              (ol.gameObject as Phaser.GameObjects.Image).texture.key,
+          ),
         ).length === 0;
 
     if (canDrop) {


### PR DESCRIPTION
This pull request introduces updates to improve gameplay mechanics and clean up unused imports. Key changes include adding new interaction-related constants, refining item drop mechanics, and removing an unused import.

### Gameplay Mechanics Updates:
* [`frontend/src/config.ts`](diffhunk://#diff-fa2c9e63d85b91989ec85c89b8143cfc9c5cf949ec4fee597c7923d4c57c1727R19-R22): Added new constants `NPC_INTERACTION_DISTANCE` and `WRONG_ITEM_HEALTH_PENALTY` to define interaction distance and health penalty for incorrect item usage.
* [`frontend/src/scenes/levels/base-level-scene.ts`](diffhunk://#diff-a8dabbd1c0850c207bc95b6ea3a89c2070152ac25e2c83ed8b8d9864625c9e8cL249-R290): Updated the item drop logic in the `tryDropHeldItem` method to use `dropAreaSize` and `dropOffset` for more precise drop positioning. Also, replaced hardcoded filtering logic with a dynamic check against `this.obstacles`.

### Code Cleanup:
* [`frontend/src/scenes/levels/base-level-scene.ts`](diffhunk://#diff-a8dabbd1c0850c207bc95b6ea3a89c2070152ac25e2c83ed8b8d9864625c9e8cL24-R24): Removed the unused `TileKeys` import from the assets module.